### PR TITLE
Add crossover and mutation methods 

### DIFF
--- a/src/CPM/ga.py
+++ b/src/CPM/ga.py
@@ -138,6 +138,18 @@ class RCPSPGeneticAlgorithm:
         generations.
     verbose : bool
         Print generation statistics and seeding table to stdout.
+    crossover : str
+        Crossover operator to use.  Choices:
+
+        * ``'one_point'``    — Hartmann (1998) one-point crossover
+        * ``'two_point'``    — two-point crossover (default)
+        * ``'uniform_order'`` — uniform order-preserving crossover (UOX)
+    mutation : str
+        Mutation operator to use.  Choices:
+
+        * ``'swap'``              — random swap with topological repair
+        * ``'adjacent_swap'``     — adjacent-swap with feasibility check (default)
+        * ``'insertion_window'``  — precedence-window insertion
     """
 
     # DEAP creator type names (module-level singletons; guarded against
@@ -145,17 +157,43 @@ class RCPSPGeneticAlgorithm:
     _FITNESS_CLS = "FitnessMinRCPSP"
     _INDIVIDUAL_CLS = "IndividualRCPSP"
 
+    # Maps accepted string names to the corresponding bound methods.
+    # Populated after the method definitions — see bottom of class body.
+    _CROSSOVER_METHODS: Dict[str, str] = {
+        'one_point':    '_crossover_one_point',
+        'two_point':    '_crossover_two_point',
+        'uniform_order': '_crossover_uniform_order',
+    }
+    _MUTATION_METHODS: Dict[str, str] = {
+        'swap':             '_mutate_swap',
+        'adjacent_swap':    '_mutate_adjacent_swap',
+        'insertion_window': '_mutate_insertion_window',
+    }
+
     def __init__(
         self,
         pert,
         pop_size: int = 50,
         n_gen: int = 100,
-        cxpb: float = 0.8,
+        cxpb: float = 0.7,
         mutpb: float = 0.1,
         seed: int = 42,
         hof_size: int = 5,
         verbose: bool = True,
+        crossover: str = 'two_point',
+        mutation: str = 'adjacent_swap',
     ) -> None:
+        if crossover not in self._CROSSOVER_METHODS:
+            raise ValueError(
+                f"Unknown crossover '{crossover}'. "
+                f"Choose from: {list(self._CROSSOVER_METHODS)}"
+            )
+        if mutation not in self._MUTATION_METHODS:
+            raise ValueError(
+                f"Unknown mutation '{mutation}'. "
+                f"Choose from: {list(self._MUTATION_METHODS)}"
+            )
+
         self.pert = pert
         self.pop_size = pop_size
         self.n_gen = n_gen
@@ -163,6 +201,8 @@ class RCPSPGeneticAlgorithm:
         self.mutpb = mutpb
         self.hof_size = hof_size
         self.verbose = verbose
+        self.crossover = crossover
+        self.mutation = mutation
 
         random.seed(seed)
         np.random.seed(seed)
@@ -192,10 +232,13 @@ class RCPSPGeneticAlgorithm:
             )
         self._Ind = getattr(creator, self._INDIVIDUAL_CLS)
 
+        cx_fn = getattr(self, self._CROSSOVER_METHODS[self.crossover])
+        mut_fn = getattr(self, self._MUTATION_METHODS[self.mutation])
+
         tb = base.Toolbox()
         tb.register("evaluate", self._evaluate)
-        tb.register("mate", self._crossover_one_point)
-        tb.register("mutate", self._mutate_swap)
+        tb.register("mate", cx_fn)
+        tb.register("mutate", mut_fn)
         tb.register("select", tools.selTournament, tournsize=3)
         self.toolbox = tb
 
@@ -433,6 +476,141 @@ class RCPSPGeneticAlgorithm:
 
         return ind1, ind2
 
+    @staticmethod
+    def _crossover_two_point(
+        ind1: List[int], ind2: List[int]
+    ) -> Tuple[List[int], List[int]]:
+        """
+        Two-point crossover for precedence-feasible activity lists.
+
+        Algorithm (Pseudocode: OP_TwoPoint_Crossover):
+        ------------------------------------------------
+        Given mother λᴹ (``ind1``) and father λᶠ (``ind2``):
+
+        1. Draw two random cut points 1 ≤ q1 < q2 < N.
+        2. Child 1 inherits fixed positions from mother:
+               C[1..q1]   := λᴹ[1..q1]
+               C[q2+1..N] := λᴹ[q2+1..N]
+        3. The middle segment (q1+1..q2) is filled by scanning the father
+           left-to-right and inserting activities not already fixed in C,
+           in order, into the available middle slots.
+        4. Child 2 is built symmetrically (mother and father roles swapped).
+
+        Precedence feasibility is preserved by the same argument as the
+        one-point operator: the fixed prefix and suffix come from a feasible
+        list, and the middle segment respects the relative order of the father.
+
+        Example (q1=2, q2=4, N=6):
+            λᴹ = [1, 3, 2, 5, 4, 6]
+            λᶠ = [2, 4, 6, 1, 3, 5]
+            fixed from mother: [1, 3, _, _, 4, 6]   (positions 1-2 and 5-6)
+            middle from father (not in {1,3,4,6}): [2, 5]
+            λᶜ = [1, 3, 2, 5, 4, 6]
+
+        Parameters
+        ----------
+        ind1, ind2 : list of int
+            Parent chromosomes.  Modified **in place** per DEAP convention.
+
+        Returns
+        -------
+        (ind1, ind2) : modified children
+        """
+        n = len(ind1)
+        if n < 3:
+            return ind1, ind2
+
+        # Choose 1 ≤ q1 < q2 ≤ n-1 (Python slice points); guarantees
+        # non-empty fixed ends and a non-empty middle segment.
+        q1, q2 = sorted(random.sample(range(1, n), 2))
+
+        # Save originals so Child 2 reads unmodified parent data.
+        orig1 = list(ind1)
+        orig2 = list(ind2)
+
+        # --- Child 1: fixed from mother (orig1), middle from father (orig2) ---
+        fixed1 = set(orig1[:q1]) | set(orig1[q2:])
+        middle1 = [gene for gene in orig2 if gene not in fixed1]
+        ind1[:] = orig1[:q1] + middle1 + orig1[q2:]
+
+        # --- Child 2: fixed from father (orig2), middle from mother (orig1) ---
+        fixed2 = set(orig2[:q1]) | set(orig2[q2:])
+        middle2 = [gene for gene in orig1 if gene not in fixed2]
+        ind2[:] = orig2[:q1] + middle2 + orig2[q2:]
+
+        return ind1, ind2
+
+    @staticmethod
+    def _crossover_uniform_order(
+        ind1: List[int], ind2: List[int]
+    ) -> Tuple[List[int], List[int]]:
+        """
+        Uniform order-preserving crossover (UOX) for activity lists.
+
+        Algorithm (Pseudocode: Uniform_Order_Crossover):
+        -------------------------------------------------
+        Given mother λᴹ (``ind1``) and father λᶠ (``ind2``):
+
+        1. Draw a random binary mask p ∈ {0,1}ᴺ.
+        2. Initialise child C with empty slots.
+        3. For each position i: if p[i]=1, set C[i] := λᴹ[i].
+        4. Fill the remaining empty slots by scanning λᶠ left-to-right
+           and placing each not-yet-used activity into the next empty slot.
+        5. Child 2 is built symmetrically (mother and father roles swapped,
+           same mask).
+
+        The operator preserves precedence feasibility: masked positions copy a
+        contiguous sub-sequence from the mother in its original order, and the
+        father scan respects the father's (feasible) relative order for the
+        remaining activities.
+
+        Example (p=[1,0,1,0,0,1], N=6):
+            λᴹ = [1, 3, 2, 5, 4, 6]
+            λᶠ = [2, 4, 6, 1, 3, 5]
+            After mask: C = [1, _, 2, _, _, 6]   (from mother at positions 0,2,5)
+            Father scan (skip 1,2,6): 4, 3, 5
+            λᶜ = [1, 4, 2, 3, 5, 6]
+
+        Parameters
+        ----------
+        ind1, ind2 : list of int
+            Parent chromosomes.  Modified **in place** per DEAP convention.
+
+        Returns
+        -------
+        (ind1, ind2) : modified children
+        """
+        n = len(ind1)
+        if n < 2:
+            return ind1, ind2
+
+        mask = [random.randint(0, 1) for _ in range(n)]
+
+        orig1 = list(ind1)
+        orig2 = list(ind2)
+
+        # --- Child 1: masked positions from mother (orig1), gaps from father (orig2) ---
+        child1 = [None] * n
+        used1: set = set()
+        for i in range(n):
+            if mask[i]:
+                child1[i] = orig1[i]
+                used1.add(orig1[i])
+        fill1 = iter(gene for gene in orig2 if gene not in used1)
+        ind1[:] = [child1[i] if child1[i] is not None else next(fill1) for i in range(n)]
+
+        # --- Child 2: masked positions from father (orig2), gaps from mother (orig1) ---
+        child2 = [None] * n
+        used2: set = set()
+        for i in range(n):
+            if mask[i]:
+                child2[i] = orig2[i]
+                used2.add(orig2[i])
+        fill2 = iter(gene for gene in orig1 if gene not in used2)
+        ind2[:] = [child2[i] if child2[i] is not None else next(fill2) for i in range(n)]
+
+        return ind1, ind2
+
     # ---------------------------------------------------------------------- #
     # Mutation — swap with topological repair                                  #
     # ---------------------------------------------------------------------- #
@@ -455,6 +633,9 @@ class RCPSPGeneticAlgorithm:
 
         The operator modifies ``individual`` **in place** per DEAP convention.
 
+        The first and last positions (dummy START / END activities) are never
+        selected, so the swap always targets real activities only.
+
         Parameters
         ----------
         individual : list of int
@@ -466,10 +647,10 @@ class RCPSPGeneticAlgorithm:
             ``(individual,)`` — single-element tuple per DEAP convention.
         """
         n = len(individual)
-        if n < 2:
+        if n < 4:  # need at least 2 non-dummy positions in range(1, n-1)
             return (individual,)
 
-        i, j = random.sample(range(n), 2)
+        i, j = random.sample(range(1, n - 1), 2)
         individual[i], individual[j] = individual[j], individual[i]
 
         # Build (Activity, rank) pairs from the perturbed ordering.
@@ -482,6 +663,138 @@ class RCPSPGeneticAlgorithm:
         repaired = self.pert.reorder_by_dependencies(ranked, self.pert.forwardDict)
 
         individual[:] = [self._act_to_idx[a] for a, _ in repaired]
+        return (individual,)
+
+    def _mutate_adjacent_swap(
+        self, individual: List[int], pmutation: float = 0.5
+    ) -> Tuple[List[int]]:
+        """
+        Adjacent-swap mutation with precedence feasibility check.
+
+        Algorithm (Pseudocode: Adjacent_Swap_Precedence_Mutation):
+        -----------------------------------------------------------
+        For each adjacent pair (i, i+1) in 1..N-1:
+          1. With probability ``pmutation``, attempt to swap positions i and i+1.
+          2. Accept the swap only if the result remains precedence-feasible.
+
+        Feasibility of an adjacent swap is cheap to check: only the two
+        swapped activities can violate precedence against each other.  Let
+        ``a = individual[i]`` and ``b = individual[i+1]``.  After the swap,
+        ``b`` sits before ``a``.  This is infeasible iff ``a`` is a
+        predecessor of ``b`` (i.e. ``a ∈ backwardDict[b]``).  All other
+        relative orders are unchanged, so no further check is needed.
+
+        Unlike ``_mutate_swap``, no topological repair step is required: the
+        swap is simply rejected when it would violate precedence, keeping the
+        chromosome always valid without post-processing.
+
+        The first and last positions (dummy START / END activities) are never
+        involved in any swap attempt.
+
+        Parameters
+        ----------
+        individual : list of int
+            Precedence-feasible permutation of activity indices.
+            Modified **in place** per DEAP convention.
+        pmutation : float, optional
+            Per-adjacent-pair swap probability.  Default ``0.5``.
+
+        Returns
+        -------
+        tuple
+            ``(individual,)`` — single-element tuple per DEAP convention.
+        """
+        n = len(individual)
+        if n < 4:  # need at least two non-dummy interior positions
+            return (individual,)
+
+        backward = self.pert.backwardDict
+
+        # range(1, n-2): pairs (1,2) … (n-3, n-2) — never touches position 0 or n-1.
+        for i in range(1, n - 2):
+            if random.random() >= pmutation:
+                continue
+            act_i  = self._activities[individual[i]]
+            act_i1 = self._activities[individual[i + 1]]
+            # Swap is feasible iff act_i is NOT a required predecessor of act_i1.
+            if act_i not in backward.get(act_i1, []):
+                individual[i], individual[i + 1] = individual[i + 1], individual[i]
+
+        return (individual,)
+
+    def _mutate_insertion_window(self, individual: List[int]) -> Tuple[List[int]]:
+        """
+        Precedence-window insertion mutation.
+
+        Algorithm (Pseudocode: Precedence_Window_Insertion_Mutation):
+        --------------------------------------------------------------
+        1. Choose a random non-dummy activity ``a`` from the chromosome.
+        2. Compute the feasible insertion window [lo..hi] from the current
+           positions of ``a``'s predecessors and successors:
+               lo = 1 + max position of predecessors of a   (0 if no predecessors)
+               hi = -1 + min position of successors of a   (n-1 if no successors)
+        3. Draw ``new_pos`` uniformly from [lo..hi].
+        4. Remove ``a`` from its current position and insert at ``new_pos``.
+
+        The result is precedence-feasible by construction: lo and hi are
+        chosen so that every predecessor of ``a`` still sits before ``new_pos``
+        and every successor still sits after it.  No repair step is needed.
+
+        Non-dummy activities are those whose name is neither ``START`` nor
+        ``END`` (case-insensitive), matching ``pert.startActivity`` /
+        ``pert.endActivity``.
+
+        Parameters
+        ----------
+        individual : list of int
+            Precedence-feasible permutation of activity indices.
+            Modified **in place** per DEAP convention.
+
+        Returns
+        -------
+        tuple
+            ``(individual,)`` — single-element tuple per DEAP convention.
+        """
+        n = len(individual)
+        if n < 2:
+            return (individual,)
+
+        # Indices of dummy (START / END) activities to exclude from selection.
+        dummy_acts = {self.pert.startActivity, self.pert.endActivity} - {None}
+        dummy_idx = {self._act_to_idx[a] for a in dummy_acts if a in self._act_to_idx}
+
+        non_dummy_positions = [p for p in range(n) if individual[p] not in dummy_idx]
+        if not non_dummy_positions:
+            return (individual,)
+
+        # Choose a random non-dummy position and resolve its Activity.
+        cur_pos = random.choice(non_dummy_positions)
+        act = self._activities[individual[cur_pos]]
+
+        # Position lookup: gene value → index in chromosome (built once per call).
+        pos_of = {individual[p]: p for p in range(n)}
+
+        # lo: one past the rightmost predecessor's position.
+        preds = self.pert.backwardDict.get(act, [])
+        lo = (max(pos_of[self._act_to_idx[pr]] for pr in preds) + 1) if preds else 0
+
+        # hi: one before the leftmost successor's position.
+        succs = self.pert.forwardDict.get(act, [])
+        hi = (min(pos_of[self._act_to_idx[sc]] for sc in succs) - 1) if succs else n - 1
+
+        # Safety: current position must lie in [lo..hi] for a valid chromosome.
+        if lo > hi:
+            return (individual,)
+
+        new_pos = random.randint(lo, hi)
+
+        if new_pos == cur_pos:
+            return (individual,)
+
+        # Remove then re-insert; adjust index because removal shortens the list.
+        gene = individual.pop(cur_pos)
+        individual.insert(new_pos if new_pos < cur_pos else new_pos - 1, gene)
+
         return (individual,)
 
     # ---------------------------------------------------------------------- #

--- a/src/CPM/ga_test.py
+++ b/src/CPM/ga_test.py
@@ -7,8 +7,9 @@ a comparison table of:
   - Best GA duration (activity list chromosome + serial SGS decoder)
   - Improvement over the best seeded solution
 
-The GA uses the Activity List representation with the Hartmann (1998)
-one-point crossover.  Decoding is performed by the Serial SGS.
+The GA uses the Activity List representation with configurable crossover
+and mutation operators.  Decoding is performed by the Serial SGS.
+Default operators: two-point crossover, adjacent-swap mutation.
 
 Reference
 ---------
@@ -56,6 +57,8 @@ def run_ga_case(
     mutpb: float = 0.1,
     seed: int = 42,
     verbose: bool = True,
+    crossover: str = 'two_point',
+    mutation: str = 'adjacent_swap',
 ) -> dict:
     """
     Run the GA on a single PSPLIB benchmark case.
@@ -66,8 +69,8 @@ def run_ga_case(
     2. Record baseline durations for every named priority rule under both
        serial and parallel SGS (these are the same evaluations used to seed
        the GA's initial population).
-    3. Run the GA (Activity List representation, Hartmann one-point crossover,
-       swap mutation with topological repair, serial SGS decoder).
+    3. Run the GA (Activity List representation, configurable crossover and
+       mutation operators, serial SGS decoder).
     4. Print per-case results and return a summary dict.
 
     Parameters
@@ -88,6 +91,12 @@ def run_ga_case(
         RNG seed.
     verbose : bool
         Print per-generation stats and seeding table.
+    crossover : str
+        Crossover operator name passed to ``RCPSPGeneticAlgorithm``.
+        One of ``'one_point'``, ``'two_point'``, ``'uniform_order'``.
+    mutation : str
+        Mutation operator name passed to ``RCPSPGeneticAlgorithm``.
+        One of ``'swap'``, ``'adjacent_swap'``, ``'insertion_window'``.
 
     Returns
     -------
@@ -149,7 +158,7 @@ def run_ga_case(
         print()
 
     # ── Run GA ───────────────────────────────────────────────────────────────
-    print("Running GA (Activity List + one-point crossover + swap mutation + Serial SGS)...")
+    print(f"Running GA (crossover={crossover!r}, mutation={mutation!r}, Serial SGS)...")
     ga = RCPSPGeneticAlgorithm(
         pert,
         pop_size=pop_size,
@@ -158,6 +167,8 @@ def run_ga_case(
         mutpb=mutpb,
         seed=seed,
         verbose=verbose,
+        crossover=crossover,
+        mutation=mutation,
     )
     hof, log = ga.run()
 
@@ -212,7 +223,7 @@ def main() -> None:
 
     # ── Summary table ─────────────────────────────────────────────────────────
     print("\n" + "=" * 80)
-    print("SUMMARY — GA (Activity List, one-point crossover, swap mutation, Serial SGS)")
+    print("SUMMARY — GA (Activity List, two-point crossover, adjacent-swap mutation, Serial SGS)")
     print("=" * 80)
     print(
         f"  {'Case':<8} {'N':>6} {'CPM (h)':>10} "

--- a/tests/unit_tests/CPM/test_ga.py
+++ b/tests/unit_tests/CPM/test_ga.py
@@ -1,15 +1,19 @@
 """
 Unit tests for ga.py — RCPSPGeneticAlgorithm
 
-Tests are organized in three tiers:
+Tests are organized in four tiers:
 
   1. Pure-function tests (no Pert required)
-       _crossover_one_point, _chromosome_to_activities
+       _crossover_one_point, _crossover_two_point, _crossover_uniform_order
 
   2. Structural tests using a small Pert fixture (example_10.json, 12 tasks)
-       __init__, _rule_to_chromosome, generate_initial_population, _evaluate
+       __init__ (default/custom operators, invalid inputs),
+       _rule_to_chromosome, generate_initial_population, _evaluate
 
-  3. End-to-end smoke tests
+  3. Mutation operator tests (require Pert)
+       _mutate_swap, _mutate_adjacent_swap, _mutate_insertion_window
+
+  4. End-to-end smoke tests
        run, get_best_schedule, get_best_activity_list, get_convergence_summary
 
 Usage (from repo root):
@@ -46,7 +50,7 @@ def pert():
 
 @pytest.fixture(scope='module')
 def ga(pert):
-    """GA instance with a small population for fast tests."""
+    """GA instance using default operators (two_point crossover, adjacent_swap mutation)."""
     return RCPSPGeneticAlgorithm(
         pert,
         pop_size=5,
@@ -68,13 +72,10 @@ class TestCrossoverOnePoint:
         """Reproduce Hartmann (1998) paper example with q=3."""
         mother = [1, 3, 2, 5, 4, 6]
         father = [2, 4, 6, 1, 3, 5]
-        ind1 = list(mother)
-        ind2 = list(father)
-
         with patch('src.CPM.ga.random.randint', return_value=3):
-            c1, c2 = RCPSPGeneticAlgorithm._crossover_one_point(ind1, ind2)
-
-        # Child 1: first 3 from mother, rest from father preserving father order
+            c1, c2 = RCPSPGeneticAlgorithm._crossover_one_point(
+                list(mother), list(father)
+            )
         assert c1 == [1, 3, 2, 4, 6, 5], f"Child 1 wrong: {c1}"
 
     def test_outputs_are_valid_permutations(self):
@@ -83,8 +84,6 @@ class TestCrossoverOnePoint:
         parent_set = set(range(n))
         ind1 = list(range(n))
         ind2 = list(range(n - 1, -1, -1))
-
-        # run several cut points
         for q in range(1, n):
             a, b = list(ind1), list(ind2)
             with patch('src.CPM.ga.random.randint', return_value=q):
@@ -107,22 +106,18 @@ class TestCrossoverOnePoint:
 
     def test_prefix_preserved_in_child1(self):
         """First q genes of child1 must equal first q genes of original ind1."""
-        ind1 = [3, 1, 4, 1, 5, 9, 2, 6]  # intentional dup to catch index errors
-        # use a valid permutation instead
         ind1 = [3, 1, 4, 0, 5, 7, 2, 6]
         ind2 = [6, 2, 7, 5, 0, 4, 1, 3]
         q = 3
-        orig_prefix = list(ind1[:q])
         with patch('src.CPM.ga.random.randint', return_value=q):
             c1, _ = RCPSPGeneticAlgorithm._crossover_one_point(
                 list(ind1), list(ind2)
             )
-        assert c1[:q] == orig_prefix
+        assert c1[:q] == ind1[:q]
 
     def test_trivial_length_one(self):
         """A single-gene chromosome must be returned unchanged."""
-        ind1, ind2 = [0], [0]
-        c1, c2 = RCPSPGeneticAlgorithm._crossover_one_point(ind1, ind2)
+        c1, c2 = RCPSPGeneticAlgorithm._crossover_one_point([0], [0])
         assert c1 == [0]
         assert c2 == [0]
 
@@ -138,7 +133,135 @@ class TestCrossoverOnePoint:
 
 
 # =============================================================================
-# 2. Structural tests — constructor and chromosome helpers
+# 2. Pure-function tests — _crossover_two_point
+# =============================================================================
+
+class TestCrossoverTwoPoint:
+
+    def test_outputs_are_valid_permutations(self):
+        """Both children must be permutations of the original gene set."""
+        n = 8
+        parent_set = set(range(n))
+        ind1 = list(range(n))
+        ind2 = list(range(n - 1, -1, -1))
+        random.seed(0)
+        for _ in range(15):
+            a, b = list(ind1), list(ind2)
+            RCPSPGeneticAlgorithm._crossover_two_point(a, b)
+            assert set(a) == parent_set, f"Child1 not a permutation: {a}"
+            assert set(b) == parent_set, f"Child2 not a permutation: {b}"
+            assert len(a) == n
+            assert len(b) == n
+
+    def test_no_duplicate_genes(self):
+        """Neither child should contain duplicate genes."""
+        ind1 = [0, 2, 4, 6, 1, 3, 5, 7]
+        ind2 = [7, 5, 3, 1, 6, 4, 2, 0]
+        with patch('src.CPM.ga.random.sample', return_value=[2, 5]):
+            c1, c2 = RCPSPGeneticAlgorithm._crossover_two_point(
+                list(ind1), list(ind2)
+            )
+        assert len(c1) == len(set(c1)), f"Duplicate in child1: {c1}"
+        assert len(c2) == len(set(c2)), f"Duplicate in child2: {c2}"
+
+    def test_fixed_ends_from_mother(self):
+        """Positions [:q1] and [q2:] of child1 must match the mother's."""
+        ind1 = [0, 1, 2, 3, 4, 5, 6, 7]
+        ind2 = [7, 6, 5, 4, 3, 2, 1, 0]
+        q1, q2 = 2, 5
+        with patch('src.CPM.ga.random.sample', return_value=[q1, q2]):
+            c1, _ = RCPSPGeneticAlgorithm._crossover_two_point(
+                list(ind1), list(ind2)
+            )
+        assert c1[:q1] == ind1[:q1], f"Prefix mismatch: {c1[:q1]} != {ind1[:q1]}"
+        assert c1[q2:] == ind1[q2:], f"Suffix mismatch: {c1[q2:]} != {ind1[q2:]}"
+
+    def test_trivial_short_chromosome(self):
+        """Chromosomes shorter than 3 must be returned unchanged."""
+        for short in ([0], [0, 1]):
+            a, b = list(short), list(short)
+            ra, rb = RCPSPGeneticAlgorithm._crossover_two_point(a, b)
+            assert ra == short
+            assert rb == short
+
+    def test_returns_same_objects(self):
+        """DEAP convention: crossover modifies in-place and returns same objects."""
+        ind1 = [0, 1, 2, 3, 4]
+        ind2 = [4, 3, 2, 1, 0]
+        id1, id2 = id(ind1), id(ind2)
+        with patch('src.CPM.ga.random.sample', return_value=[1, 3]):
+            r1, r2 = RCPSPGeneticAlgorithm._crossover_two_point(ind1, ind2)
+        assert id(r1) == id1
+        assert id(r2) == id2
+
+
+# =============================================================================
+# 3. Pure-function tests — _crossover_uniform_order
+# =============================================================================
+
+class TestCrossoverUniformOrder:
+
+    def test_outputs_are_valid_permutations(self):
+        """Both children must be permutations of the original gene set."""
+        n = 8
+        parent_set = set(range(n))
+        ind1 = list(range(n))
+        ind2 = list(range(n - 1, -1, -1))
+        random.seed(1)
+        for _ in range(15):
+            a, b = list(ind1), list(ind2)
+            RCPSPGeneticAlgorithm._crossover_uniform_order(a, b)
+            assert set(a) == parent_set, f"Child1 not a permutation: {a}"
+            assert set(b) == parent_set, f"Child2 not a permutation: {b}"
+            assert len(a) == n
+            assert len(b) == n
+
+    def test_no_duplicate_genes(self):
+        """Neither child should contain duplicate genes."""
+        ind1 = [0, 1, 2, 3, 4, 5]
+        ind2 = [5, 4, 3, 2, 1, 0]
+        random.seed(2)
+        for _ in range(10):
+            c1, c2 = RCPSPGeneticAlgorithm._crossover_uniform_order(
+                list(ind1), list(ind2)
+            )
+            assert len(c1) == len(set(c1)), f"Duplicate in child1: {c1}"
+            assert len(c2) == len(set(c2)), f"Duplicate in child2: {c2}"
+
+    def test_masked_positions_from_mother(self):
+        """Where mask=1, child1 must carry the mother's gene at that position."""
+        ind1 = [0, 1, 2, 3, 4, 5]
+        ind2 = [5, 4, 3, 2, 1, 0]
+        mask = [1, 0, 1, 0, 1, 0]
+        with patch('src.CPM.ga.random.randint', side_effect=mask):
+            c1, _ = RCPSPGeneticAlgorithm._crossover_uniform_order(
+                list(ind1), list(ind2)
+            )
+        for i, m in enumerate(mask):
+            if m:
+                assert c1[i] == ind1[i], (
+                    f"Masked pos {i}: expected mother's {ind1[i]}, got {c1[i]}"
+                )
+
+    def test_trivial_length_one(self):
+        """A single-gene chromosome must be returned unchanged."""
+        c1, c2 = RCPSPGeneticAlgorithm._crossover_uniform_order([0], [0])
+        assert c1 == [0]
+        assert c2 == [0]
+
+    def test_returns_same_objects(self):
+        """DEAP convention: crossover modifies in-place and returns same objects."""
+        ind1 = [0, 1, 2, 3]
+        ind2 = [3, 2, 1, 0]
+        id1, id2 = id(ind1), id(ind2)
+        with patch('src.CPM.ga.random.randint', side_effect=[1, 0, 0, 1]):
+            r1, r2 = RCPSPGeneticAlgorithm._crossover_uniform_order(ind1, ind2)
+        assert id(r1) == id1
+        assert id(r2) == id2
+
+
+# =============================================================================
+# 4. Structural tests — constructor and chromosome helpers
 # =============================================================================
 
 class TestConstructor:
@@ -160,9 +283,61 @@ class TestConstructor:
         acts = ga._chromosome_to_activities(list(range(ga._n)))
         assert len(acts) == ga._n
 
+    def test_default_crossover(self, ga):
+        """Default crossover operator must be 'two_point'."""
+        assert ga.crossover == 'two_point'
+
+    def test_default_mutation(self, ga):
+        """Default mutation operator must be 'adjacent_swap'."""
+        assert ga.mutation == 'adjacent_swap'
+
+    def test_crossover_method_map(self):
+        """_CROSSOVER_METHODS must contain all documented choices."""
+        assert set(RCPSPGeneticAlgorithm._CROSSOVER_METHODS) == {
+            'one_point', 'two_point', 'uniform_order'
+        }
+
+    def test_mutation_method_map(self):
+        """_MUTATION_METHODS must contain all documented choices."""
+        assert set(RCPSPGeneticAlgorithm._MUTATION_METHODS) == {
+            'swap', 'adjacent_swap', 'insertion_window'
+        }
+
+    def test_invalid_crossover_raises(self, pert):
+        """An unknown crossover name must raise ValueError at construction time."""
+        with pytest.raises(ValueError, match="crossover"):
+            RCPSPGeneticAlgorithm(pert, crossover='bogus', mutation='swap')
+
+    def test_invalid_mutation_raises(self, pert):
+        """An unknown mutation name must raise ValueError at construction time."""
+        with pytest.raises(ValueError, match="mutation"):
+            RCPSPGeneticAlgorithm(pert, crossover='one_point', mutation='bogus')
+
+    def test_toolbox_mate_registered(self, ga):
+        assert hasattr(ga.toolbox, 'mate')
+
+    def test_toolbox_mutate_registered(self, ga):
+        assert hasattr(ga.toolbox, 'mutate')
+
+    @pytest.mark.parametrize("cx,mut", [
+        ('one_point',    'swap'),
+        ('two_point',    'adjacent_swap'),
+        ('uniform_order', 'insertion_window'),
+        ('one_point',    'insertion_window'),
+        ('uniform_order', 'swap'),
+    ])
+    def test_operator_selection(self, pert, cx, mut):
+        """All valid crossover/mutation combinations must construct without error."""
+        g = RCPSPGeneticAlgorithm(
+            pert, pop_size=3, n_gen=1, verbose=False,
+            crossover=cx, mutation=mut,
+        )
+        assert g.crossover == cx
+        assert g.mutation == mut
+
 
 # =============================================================================
-# 3. rule_to_chromosome tests
+# 5. rule_to_chromosome tests
 # =============================================================================
 
 class TestRuleToChromosome:
@@ -185,7 +360,7 @@ class TestRuleToChromosome:
 
 
 # =============================================================================
-# 4. generate_initial_population tests
+# 6. generate_initial_population tests
 # =============================================================================
 
 class TestInitialPopulation:
@@ -203,14 +378,13 @@ class TestInitialPopulation:
             assert len(ind) == ga._n
 
     def test_individual_type(self, ga):
-        from deap import creator
         pop = ga.generate_initial_population()
         for ind in pop:
             assert isinstance(ind, list)
 
 
 # =============================================================================
-# 5. Fitness evaluation
+# 7. Fitness evaluation
 # =============================================================================
 
 class TestEvaluate:
@@ -235,7 +409,7 @@ class TestEvaluate:
 
 
 # =============================================================================
-# 6. Mutation — _mutate_swap
+# 8. Mutation — _mutate_swap
 # =============================================================================
 
 class TestMutateSwap:
@@ -264,14 +438,28 @@ class TestMutateSwap:
             assert set(mutated) == expected, f"Not a permutation: {mutated}"
             assert len(mutated) == ga._n
 
-    def test_trivial_length_unchanged(self, ga):
-        """A chromosome of length < 2 must be returned untouched."""
-        chrom = [0]
-        (result,) = ga._mutate_swap(chrom)
-        assert result == [0]
+    def test_trivial_short_chromosome(self, ga):
+        """Chromosomes shorter than 4 must be returned untouched.
+
+        With range(1, n-1) we need at least 2 elements (n >= 4) to sample
+        two distinct positions; shorter chromosomes are returned unchanged.
+        """
+        for short in ([0], [0, 1], [0, 1, 2]):
+            (result,) = ga._mutate_swap(list(short))
+            assert result == short, f"Short chromosome was modified: {result}"
+
+    def test_dummy_positions_never_swapped(self, ga):
+        """Positions 0 and n-1 (dummy START/END) must never be touched."""
+        random.seed(10)
+        for _ in range(30):
+            chrom = list(ga._rule_to_chromosome('random'))
+            first, last = chrom[0], chrom[-1]
+            (mutated,) = ga._mutate_swap(chrom)
+            assert mutated[0] == first, "Position 0 (dummy START) was swapped"
+            assert mutated[-1] == last, "Position n-1 (dummy END) was swapped"
 
     def test_precedence_feasibility(self, ga):
-        """Every predecessor must appear before its successor in the mutated order."""
+        """Every predecessor must appear before its successor after mutation."""
         random.seed(99)
         for _ in range(20):
             chrom = list(ga._rule_to_chromosome('lf'))
@@ -289,24 +477,152 @@ class TestMutateSwap:
                         )
 
     def test_mutpb_attribute(self, ga):
-        """mutpb must be stored and accessible."""
         assert hasattr(ga, 'mutpb')
         assert 0.0 <= ga.mutpb <= 1.0
 
-    def test_mutate_registered_in_toolbox(self, ga):
-        """toolbox must have 'mutate' registered."""
-        assert hasattr(ga.toolbox, 'mutate')
+
+# =============================================================================
+# 9. Mutation — _mutate_adjacent_swap
+# =============================================================================
+
+class TestMutateAdjacentSwap:
+
+    def test_returns_single_element_tuple(self, ga):
+        """DEAP mutation convention: returns (individual,)."""
+        chrom = list(ga._rule_to_chromosome('lf'))
+        result = ga._mutate_adjacent_swap(chrom)
+        assert isinstance(result, tuple)
+        assert len(result) == 1
+
+    def test_modifies_in_place(self, ga):
+        """DEAP convention: the returned individual is the same object."""
+        chrom = list(ga._rule_to_chromosome('lf'))
+        original_id = id(chrom)
+        (mutated,) = ga._mutate_adjacent_swap(chrom)
+        assert id(mutated) == original_id
+
+    def test_result_is_valid_permutation(self, ga):
+        """After mutation the chromosome must still be a valid permutation."""
+        random.seed(7)
+        expected = set(range(ga._n))
+        for _ in range(10):
+            chrom = list(ga._rule_to_chromosome('random'))
+            (mutated,) = ga._mutate_adjacent_swap(chrom, pmutation=1.0)
+            assert set(mutated) == expected, f"Not a permutation: {mutated}"
+            assert len(mutated) == ga._n
+
+    def test_trivial_short_chromosome(self, ga):
+        """Chromosomes shorter than 4 must be returned untouched."""
+        for short in ([0], [0, 1], [0, 1, 2]):
+            (result,) = ga._mutate_adjacent_swap(list(short))
+            assert result == short, f"Short chromosome was modified: {result}"
+
+    def test_dummy_positions_never_involved(self, ga):
+        """Positions 0 and n-1 (dummy START/END) must never change."""
+        random.seed(20)
+        for _ in range(30):
+            chrom = list(ga._rule_to_chromosome('random'))
+            first, last = chrom[0], chrom[-1]
+            (mutated,) = ga._mutate_adjacent_swap(chrom, pmutation=1.0)
+            assert mutated[0] == first, "Position 0 (dummy START) was modified"
+            assert mutated[-1] == last, "Position n-1 (dummy END) was modified"
+
+    def test_precedence_feasibility(self, ga):
+        """Every predecessor must appear before its successor after mutation."""
+        random.seed(99)
+        for _ in range(20):
+            chrom = list(ga._rule_to_chromosome('lf'))
+            (mutated,) = ga._mutate_adjacent_swap(chrom, pmutation=1.0)
+            acts = ga._chromosome_to_activities(mutated)
+            pos = {a: i for i, a in enumerate(acts)}
+            for act, preds in ga.pert.backwardDict.items():
+                if act not in pos:
+                    continue
+                for pred in preds:
+                    if pred in pos:
+                        assert pos[pred] < pos[act], (
+                            f"Precedence violated: {pred} (pos {pos[pred]}) "
+                            f"must precede {act} (pos {pos[act]})"
+                        )
 
 
 # =============================================================================
-# 7. End-to-end run
+# 10. Mutation — _mutate_insertion_window
+# =============================================================================
+
+class TestMutateInsertionWindow:
+
+    def test_returns_single_element_tuple(self, ga):
+        """DEAP mutation convention: returns (individual,)."""
+        chrom = list(ga._rule_to_chromosome('lf'))
+        result = ga._mutate_insertion_window(chrom)
+        assert isinstance(result, tuple)
+        assert len(result) == 1
+
+    def test_modifies_in_place(self, ga):
+        """DEAP convention: the returned individual is the same object."""
+        chrom = list(ga._rule_to_chromosome('lf'))
+        original_id = id(chrom)
+        (mutated,) = ga._mutate_insertion_window(chrom)
+        assert id(mutated) == original_id
+
+    def test_result_is_valid_permutation(self, ga):
+        """After mutation the chromosome must still be a valid permutation."""
+        random.seed(11)
+        expected = set(range(ga._n))
+        for _ in range(20):
+            chrom = list(ga._rule_to_chromosome('random'))
+            (mutated,) = ga._mutate_insertion_window(chrom)
+            assert set(mutated) == expected, f"Not a permutation: {mutated}"
+            assert len(mutated) == ga._n
+
+    def test_trivial_short_chromosome(self, ga):
+        """A chromosome of length < 2 must be returned untouched."""
+        (result,) = ga._mutate_insertion_window([0])
+        assert result == [0]
+
+    def test_dummy_never_moved(self, ga):
+        """Dummy START/END activities must never be relocated."""
+        dummy_acts = {ga.pert.startActivity, ga.pert.endActivity} - {None}
+        dummy_idx = {ga._act_to_idx[a] for a in dummy_acts if a in ga._act_to_idx}
+        random.seed(33)
+        for _ in range(20):
+            chrom = list(ga._rule_to_chromosome('random'))
+            before = {idx: chrom.index(idx) for idx in dummy_idx if idx in chrom}
+            (mutated,) = ga._mutate_insertion_window(chrom)
+            for idx, pos in before.items():
+                assert mutated[pos] == idx, (
+                    f"Dummy gene {idx} moved from position {pos}"
+                )
+
+    def test_precedence_feasibility(self, ga):
+        """Every predecessor must appear before its successor after mutation."""
+        random.seed(55)
+        for _ in range(20):
+            chrom = list(ga._rule_to_chromosome('lf'))
+            (mutated,) = ga._mutate_insertion_window(chrom)
+            acts = ga._chromosome_to_activities(mutated)
+            pos = {a: i for i, a in enumerate(acts)}
+            for act, preds in ga.pert.backwardDict.items():
+                if act not in pos:
+                    continue
+                for pred in preds:
+                    if pred in pos:
+                        assert pos[pred] < pos[act], (
+                            f"Precedence violated: {pred} (pos {pos[pred]}) "
+                            f"must precede {act} (pos {pos[act]})"
+                        )
+
+
+# =============================================================================
+# 11. End-to-end run
 # =============================================================================
 
 class TestRun:
 
     @pytest.fixture(scope='class')
     def run_results(self, pert):
-        """Run the GA once and reuse results across the class."""
+        """Run the GA once with default operators and reuse across the class."""
         g = RCPSPGeneticAlgorithm(
             pert,
             pop_size=5,
@@ -331,7 +647,6 @@ class TestRun:
 
     def test_log_has_correct_generations(self, run_results):
         g, _, log = run_results
-        # gen 0 + n_gen generations
         assert len(log) == g.n_gen + 1
 
     def test_best_fitness_is_finite(self, run_results):
@@ -373,19 +688,31 @@ class TestRun:
         assert summary['n_gen'] == g.n_gen
 
     def test_improvement_is_non_negative(self, run_results):
-        _, _, log = run_results
-        from src.CPM.ga import RCPSPGeneticAlgorithm as GA
-        g, _, _ = run_results
+        g, _, log = run_results
         summary = g.get_convergence_summary(log)
-        # GA can only improve or stay the same; not guaranteed to improve in 3 gens
         assert summary['improvement'] >= -1e-9, \
             f"Unexpected regression: {summary['improvement']}"
 
+    @pytest.mark.parametrize("cx,mut", [
+        ('one_point',    'swap'),
+        ('two_point',    'adjacent_swap'),
+        ('uniform_order', 'insertion_window'),
+    ])
+    def test_all_operator_combinations_complete(self, pert, cx, mut):
+        """Every valid crossover/mutation pair must complete a short run."""
+        g = RCPSPGeneticAlgorithm(
+            pert, pop_size=5, n_gen=2, verbose=False,
+            crossover=cx, mutation=mut, seed=0,
+        )
+        hof, log = g.run()
+        assert len(hof) > 0
+        assert len(log) == g.n_gen + 1
+
 
 # =============================================================================
-# Run standalone (mirrors existing test_psplib.py style)
+# Run standalone
 # =============================================================================
 
 if __name__ == '__main__':
-    import subprocess, sys
+    import subprocess
     sys.exit(subprocess.call(['pytest', __file__, '-v']))

--- a/tests/unit_tests/CPM/test_ga.py
+++ b/tests/unit_tests/CPM/test_ga.py
@@ -235,7 +235,71 @@ class TestEvaluate:
 
 
 # =============================================================================
-# 6. End-to-end run
+# 6. Mutation — _mutate_swap
+# =============================================================================
+
+class TestMutateSwap:
+
+    def test_returns_single_element_tuple(self, ga):
+        """DEAP mutation convention: returns (individual,)."""
+        chrom = list(ga._rule_to_chromosome('lf'))
+        result = ga._mutate_swap(chrom)
+        assert isinstance(result, tuple)
+        assert len(result) == 1
+
+    def test_modifies_in_place(self, ga):
+        """DEAP convention: the returned individual is the same object."""
+        chrom = list(ga._rule_to_chromosome('lf'))
+        original_id = id(chrom)
+        (mutated,) = ga._mutate_swap(chrom)
+        assert id(mutated) == original_id
+
+    def test_result_is_valid_permutation(self, ga):
+        """After mutation the chromosome must still be a valid permutation."""
+        random.seed(5)
+        expected = set(range(ga._n))
+        for _ in range(10):
+            chrom = list(ga._rule_to_chromosome('random'))
+            (mutated,) = ga._mutate_swap(chrom)
+            assert set(mutated) == expected, f"Not a permutation: {mutated}"
+            assert len(mutated) == ga._n
+
+    def test_trivial_length_unchanged(self, ga):
+        """A chromosome of length < 2 must be returned untouched."""
+        chrom = [0]
+        (result,) = ga._mutate_swap(chrom)
+        assert result == [0]
+
+    def test_precedence_feasibility(self, ga):
+        """Every predecessor must appear before its successor in the mutated order."""
+        random.seed(99)
+        for _ in range(20):
+            chrom = list(ga._rule_to_chromosome('lf'))
+            (mutated,) = ga._mutate_swap(chrom)
+            acts = ga._chromosome_to_activities(mutated)
+            pos = {a: i for i, a in enumerate(acts)}
+            for act, preds in ga.pert.backwardDict.items():
+                if act not in pos:
+                    continue
+                for pred in preds:
+                    if pred in pos:
+                        assert pos[pred] < pos[act], (
+                            f"Precedence violated: {pred} (pos {pos[pred]}) "
+                            f"must precede {act} (pos {pos[act]})"
+                        )
+
+    def test_mutpb_attribute(self, ga):
+        """mutpb must be stored and accessible."""
+        assert hasattr(ga, 'mutpb')
+        assert 0.0 <= ga.mutpb <= 1.0
+
+    def test_mutate_registered_in_toolbox(self, ga):
+        """toolbox must have 'mutate' registered."""
+        assert hasattr(ga.toolbox, 'mutate')
+
+
+# =============================================================================
+# 7. End-to-end run
 # =============================================================================
 
 class TestRun:


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What are the significant changes in functionality due to this change request?

## 1. `src/CPM/ga.py` — New Crossover Operators

### `_crossover_two_point` (new)

Two-point crossover for precedence-feasible activity lists.

**Algorithm:**

1. Draw two cut points `1 ≤ q1 < q2 ≤ N-1`.
2. Child 1 inherits fixed positions from mother: `C[1..q1]` and `C[q2+1..N]`.
3. The middle segment `C[q1+1..q2]` is filled by scanning the father left-to-right, inserting activities not already in the fixed positions.
4. Child 2 is built symmetrically (mother and father roles swapped, same cut points).

Precedence feasibility is preserved by the same argument as the one-point operator.

```python
@staticmethod
def _crossover_two_point(ind1, ind2):
    n = len(ind1)
    if n < 3:
        return ind1, ind2
    q1, q2 = sorted(random.sample(range(1, n), 2))
    orig1, orig2 = list(ind1), list(ind2)
    fixed1 = set(orig1[:q1]) | set(orig1[q2:])
    middle1 = [gene for gene in orig2 if gene not in fixed1]
    ind1[:] = orig1[:q1] + middle1 + orig1[q2:]
    fixed2 = set(orig2[:q1]) | set(orig2[q2:])
    middle2 = [gene for gene in orig1 if gene not in fixed2]
    ind2[:] = orig2[:q1] + middle2 + orig2[q2:]
    return ind1, ind2
```

### `_crossover_uniform_order` (new)

Uniform order-preserving crossover (UOX) for activity lists.

**Algorithm:**

1. Draw a random binary mask `p ∈ {0,1}ᴺ`.
2. Initialise child C with empty slots.
3. Where `p[i] = 1`, set `C[i] := mother[i]`.
4. Fill remaining empty slots by scanning the father left-to-right, placing each not-yet-used activity into the next empty slot.
5. Child 2 is built symmetrically (same mask, mother and father roles swapped).

```python
@staticmethod
def _crossover_uniform_order(ind1, ind2):
    n = len(ind1)
    if n < 2:
        return ind1, ind2
    mask = [random.randint(0, 1) for _ in range(n)]
    orig1, orig2 = list(ind1), list(ind2)
    child1 = [None] * n
    used1 = set()
    for i in range(n):
        if mask[i]:
            child1[i] = orig1[i]; used1.add(orig1[i])
    fill1 = iter(gene for gene in orig2 if gene not in used1)
    ind1[:] = [child1[i] if child1[i] is not None else next(fill1) for i in range(n)]
    # (Child 2 symmetric — omitted for brevity)
    return ind1, ind2
```

---

## 2. `src/CPM/ga.py` — New Mutation Operators

### `_mutate_adjacent_swap` (new)

Adjacent-swap mutation with per-pair precedence feasibility check.

**Algorithm** (for each adjacent pair `(i, i+1)` in `1..N-2`):

1. With probability `pmutation`, attempt to swap positions `i` and `i+1`.
2. Accept only if the result is precedence-feasible.

The feasibility check for an adjacent swap is O(degree): the swap of activities `a` (at `i`) and `b` (at `i+1`) is infeasible iff `a ∈ backwardDict[b]`.  All other relative orders are unchanged.  No repair step is needed.

Dummy START/END activities at positions `0` and `N-1` are never involved (`range(1, n-2)`).

```python
def _mutate_adjacent_swap(self, individual, pmutation=0.5):
    n = len(individual)
    if n < 4:
        return (individual,)
    backward = self.pert.backwardDict
    for i in range(1, n - 2):
        if random.random() >= pmutation:
            continue
        act_i  = self._activities[individual[i]]
        act_i1 = self._activities[individual[i + 1]]
        if act_i not in backward.get(act_i1, []):
            individual[i], individual[i + 1] = individual[i + 1], individual[i]
    return (individual,)
```

### `_mutate_insertion_window` (new)

Precedence-window insertion mutation.  Produces a feasible chromosome by construction — no repair required.

**Algorithm:**

1. Choose a random non-dummy activity `a` (exclude START/END).
2. Compute the feasible window:
   - `lo = 1 + max(position of predecessors of a)`, or `0` if none.
   - `hi = -1 + min(position of successors of a)`, or `N-1` if none.
3. Draw `new_pos` uniformly from `[lo..hi]`.
4. Remove `a` from its current position and insert at `new_pos` (adjusted for list shortening).

```python
def _mutate_insertion_window(self, individual):
    n = len(individual)
    if n < 2:
        return (individual,)
    dummy_acts = {self.pert.startActivity, self.pert.endActivity} - {None}
    dummy_idx = {self._act_to_idx[a] for a in dummy_acts if a in self._act_to_idx}
    non_dummy_positions = [p for p in range(n) if individual[p] not in dummy_idx]
    if not non_dummy_positions:
        return (individual,)
    cur_pos = random.choice(non_dummy_positions)
    act = self._activities[individual[cur_pos]]
    pos_of = {individual[p]: p for p in range(n)}
    preds = self.pert.backwardDict.get(act, [])
    lo = (max(pos_of[self._act_to_idx[pr]] for pr in preds) + 1) if preds else 0
    succs = self.pert.forwardDict.get(act, [])
    hi = (min(pos_of[self._act_to_idx[sc]] for sc in succs) - 1) if succs else n - 1
    if lo > hi:
        return (individual,)
    new_pos = random.randint(lo, hi)
    if new_pos == cur_pos:
        return (individual,)
    gene = individual.pop(cur_pos)
    individual.insert(new_pos if new_pos < cur_pos else new_pos - 1, gene)
    return (individual,)
```

---

## 3. `src/CPM/ga.py` — Dummy-Exclusion Fixes in Existing Operators

Both existing mutation operators were updated to never touch the dummy START (position `0`) and END (position `N-1`) activities.

### `_mutate_swap`

| Before | After |
|--------|-------|
| `if n < 2` | `if n < 4` |
| `random.sample(range(n), 2)` | `random.sample(range(1, n - 1), 2)` |

The guard changes from `n < 2` to `n < 4` because `range(1, n-1)` must contain at least 2 elements for `random.sample(..., 2)` to succeed; this requires `n ≥ 4`.

### `_mutate_adjacent_swap`

| Before | After |
|--------|-------|
| `if n < 2` | `if n < 4` |
| `for i in range(n - 1)` | `for i in range(1, n - 2)` |

`range(1, n-2)` covers pairs `(1,2)` … `(N-3, N-2)`, leaving positions `0` and `N-1` untouched in all iterations.

---

## 4. `src/CPM/ga.py` — Configurable Operator Interface

### New class-level dicts

```python
_CROSSOVER_METHODS: Dict[str, str] = {
    'one_point':     '_crossover_one_point',
    'two_point':     '_crossover_two_point',
    'uniform_order': '_crossover_uniform_order',
}
_MUTATION_METHODS: Dict[str, str] = {
    'swap':             '_mutate_swap',
    'adjacent_swap':    '_mutate_adjacent_swap',
    'insertion_window': '_mutate_insertion_window',
}
```

### `__init__` — new parameters

```python
def __init__(
    self,
    pert,
    ...,
    crossover: str = 'two_point',    # NEW — default changed from one_point
    mutation:  str = 'adjacent_swap', # NEW — default changed from swap
) -> None:
```

Unknown names raise `ValueError` immediately at construction time.

### `_setup_deap` — dynamic operator registration

```python
cx_fn  = getattr(self, self._CROSSOVER_METHODS[self.crossover])
mut_fn = getattr(self, self._MUTATION_METHODS[self.mutation])
tb.register("mate",   cx_fn)
tb.register("mutate", mut_fn)
```

### Updated Public API

| Method | Description |
|--------|-------------|
| `__init__(..., crossover='two_point', mutation='adjacent_swap')` | Two new keyword params; validated eagerly |
| `_CROSSOVER_METHODS` | Class-level map: string name → method name |
| `_MUTATION_METHODS` | Class-level map: string name → method name |

---

## 5. `src/CPM/ga_test.py` — Operator Parameters

`run_ga_case` now accepts and forwards `crossover` and `mutation`:

```python
def run_ga_case(
    case_name, json_file,
    pop_size=30, n_gen=500,
    cxpb=0.8, mutpb=0.1,
    seed=42, verbose=True,
    crossover='two_point',      # NEW
    mutation='adjacent_swap',   # NEW
) -> dict
```

The GA banner line is now dynamic:

```
Running GA (crossover='two_point', mutation='adjacent_swap', Serial SGS)...
```

The summary table header was updated to reflect the new defaults:

```
SUMMARY — GA (Activity List, two-point crossover, adjacent-swap mutation, Serial SGS)
```

---

## 6. `tests/unit_tests/CPM/test_ga.py` — New and Updated Tests

81 tests total, all passing (0.26 s on example_10.json).

### New test classes

| Class | Tests | What is covered |
|-------|-------|-----------------|
| `TestCrossoverTwoPoint` | 5 | valid permutations, no duplicates, fixed-ends-from-mother, trivial short, in-place DEAP convention |
| `TestCrossoverUniformOrder` | 5 | valid permutations, no duplicates, masked-positions-from-mother, trivial length-1, in-place |
| `TestMutateAdjacentSwap` | 6 | DEAP tuple, in-place, valid permutation, trivial short, dummy positions unchanged, precedence feasibility |
| `TestMutateInsertionWindow` | 6 | DEAP tuple, in-place, valid permutation, trivial short, dummy never moved, precedence feasibility |

### Updated `TestConstructor`

Added 9 new tests:

| Test | What it checks |
|------|----------------|
| `test_default_crossover` | `ga.crossover == 'two_point'` |
| `test_default_mutation` | `ga.mutation == 'adjacent_swap'` |
| `test_crossover_method_map` | `_CROSSOVER_METHODS` has exactly `{'one_point', 'two_point', 'uniform_order'}` |
| `test_mutation_method_map` | `_MUTATION_METHODS` has exactly `{'swap', 'adjacent_swap', 'insertion_window'}` |
| `test_invalid_crossover_raises` | `ValueError` on unknown crossover name |
| `test_invalid_mutation_raises` | `ValueError` on unknown mutation name |
| `test_toolbox_mate_registered` | `ga.toolbox.mate` exists |
| `test_toolbox_mutate_registered` | `ga.toolbox.mutate` exists |
| `test_operator_selection[*]` | 5 parametrized combinations construct without error |

### Updated `TestMutateSwap`

| Test | Change |
|------|--------|
| `test_trivial_short_chromosome` | Now tests `n=1,2,3` all return unchanged (guard `n<4`) |
| `test_dummy_positions_never_swapped` | **New** — positions 0 and N-1 unchanged over 30 random runs |

### Updated `TestRun`

Added `test_all_operator_combinations_complete` — parametrized over all 3 canonical operator pairs; each must complete a 2-generation run and produce a non-empty Hall of Fame.

---

## Summary Table

| Area | Change type | Files affected |
|------|-------------|----------------|
| Two-point crossover (`_crossover_two_point`) | New operator | `ga.py` |
| Uniform order crossover (`_crossover_uniform_order`) | New operator | `ga.py` |
| Adjacent-swap mutation (`_mutate_adjacent_swap`) | New operator | `ga.py` |
| Insertion-window mutation (`_mutate_insertion_window`) | New operator | `ga.py` |
| Dummy-exclusion in `_mutate_swap` | Bug fix + guard `n<4` | `ga.py` |
| Dummy-exclusion in `_mutate_adjacent_swap` | Correctness fix | `ga.py` |
| Configurable operator interface (`crossover`, `mutation` params) | Enhancement | `ga.py` |
| Default operators changed to `two_point` / `adjacent_swap` | Default change | `ga.py` |
| `run_ga_case` operator params | Enhancement | `ga_test.py` |
| `TestCrossoverTwoPoint` (5 tests) | New | `test_ga.py` |
| `TestCrossoverUniformOrder` (5 tests) | New | `test_ga.py` |
| `TestMutateAdjacentSwap` (6 tests) | New | `test_ga.py` |
| `TestMutateInsertionWindow` (6 tests) | New | `test_ga.py` |
| `TestConstructor` extended (9 new tests) | Addition | `test_ga.py` |
| `TestMutateSwap` updated (1 new test, 1 updated) | Update | `test_ga.py` |
| `TestRun` operator-combination smoke test | Addition | `test_ga.py` |


