### PR TITLE
Implement ALNS method for RCPSP problem

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -14,6 +14,7 @@
     <pandas source='pip'/>
     <deap source='pip'/>
     <pytest source="pip"/>
+    <alns source='pip'/>
   </main>
 
   <alternate name="pip">

--- a/src/CPM/alns_test.py
+++ b/src/CPM/alns_test.py
@@ -1,0 +1,249 @@
+"""
+alns_test.py — Integration test for the RCPSP ALNS solver (rcpsp_alns.py)
+
+Runs the Adaptive Large Neighbourhood Search on each PSPLIB benchmark JSON
+(j30, j60, j90, j120) and prints a comparison table of:
+
+  - CPM duration (unconstrained)
+  - Best duration from all named priority rules (serial + parallel SGS)
+  - Best ALNS duration (activity list + serial SGS decoder)
+  - Improvement over the best seeded solution
+
+The ALNS uses three destroy operators (most_mobile, segment, random) and two
+repair operators (random_insert, greedy_insert) with SegmentedRouletteWheel
+selection.  The acceptance criterion and other hyper-parameters can be
+configured per-case via ``run_alns_case``.
+
+Reference
+---------
+Wouda, N.A., and L. Lan (2023).  ALNS: a Python implementation.
+  *Journal of Open Source Software*, 8(81): 5028.
+
+Usage (from the src/CPM directory):
+    python alns_test.py
+
+Or from the repo root:
+    python -m src.CPM.alns_test
+"""
+
+import sys
+import logging
+from pathlib import Path
+
+# Ensure repo root is on the path before project imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src import Pert  # noqa: E402
+from src.CPM.rcpsp_alns import (  # noqa: E402
+    RCPSPAdaptiveLNS,
+    SEED_PRIORITY_RULES,
+)
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+SCHEMA = Path(__file__).parent / "outage_schema.json"
+
+CASES = [
+    ("j30",  "j301_1.json"),
+    ("j60",  "j601_1.json"),
+    ("j90",  "j901_1.json"),
+    ("j120", "j1201_1.json"),
+]
+
+# Extra priority rules for the baseline (superset of SEED_PRIORITY_RULES)
+ALL_PRIORITY_RULES = SEED_PRIORITY_RULES + [
+    'random', 'irsm',
+    'mehh_8000_b', 'mehh_3375_b', 'mehh_1000_b', 'mehh_125_b', 'gphh_b',
+]
+
+
+def run_alns_case(
+    case_name: str,
+    json_file: str,
+    n_iter: int = 2000,
+    destroy_fraction: float = 0.25,
+    theta: float = 0.8,
+    seg_length: int = 100,
+    seed: int = 42,
+    accept: str = 'hill_climbing',
+    destroy_ops: list = None,
+    repair_ops: list = None,
+    verbose: bool = True,
+) -> dict:
+    """
+    Run the ALNS on a single PSPLIB benchmark case.
+
+    Steps
+    -----
+    1. Load and initialise the Pert model.
+    2. Record baseline durations for every named priority rule under both
+       serial and parallel SGS (these include the rules used to seed the
+       ALNS initial solution).
+    3. Run the ALNS (destroy/repair on Activity List representation, serial
+       SGS decoder).
+    4. Print per-case results and return a summary dict.
+
+    Parameters
+    ----------
+    case_name : str
+        Human-readable label (e.g. 'j30').
+    json_file : str
+        Path to the input JSON relative to this file's directory.
+    n_iter : int
+        Total ALNS iterations.
+    destroy_fraction : float
+        Fraction of non-dummy activities removed per destroy step.
+    theta : float
+        Segment-decay factor for SegmentedRouletteWheel.
+    seg_length : int
+        Iterations per segment for SegmentedRouletteWheel.
+    seed : int
+        RNG seed.
+    accept : str
+        Acceptance criterion: 'hill_climbing', 'record_to_record', or
+        'simulated_annealing'.
+    destroy_ops : list of str, optional
+        Destroy operators to use; defaults to all three.
+    repair_ops : list of str, optional
+        Repair operators to use; defaults to both.
+    verbose : bool
+        Print per-iteration seeding table and operator usage stats.
+
+    Returns
+    -------
+    dict with keys:
+        case, n_activities, cpm_duration,
+        best_serial_seed, best_parallel_seed, best_alns, improvement
+    """
+    json_path = Path(__file__).parent / json_file
+
+    print("=" * 70)
+    print(f"Case: {case_name}  ({json_file})")
+    print("=" * 70)
+
+    # ── Load and initialise Pert model ───────────────────────────────────────
+    pert = Pert.from_json_file(str(json_path), schema_path=str(SCHEMA))
+    pert.generateInfo()
+
+    cpm_duration = pert.getProjectDuration()
+    n_activities = len(pert.infoDict)
+
+    print(f"Activities      : {n_activities}")
+    print(f"CPM duration    : {cpm_duration:.2f} h  (unconstrained)")
+    print()
+
+    # ── Baseline: best duration from all named priority rules ─────────────────
+    serial_durations = {}
+    parallel_durations = {}
+
+    for rule in ALL_PRIORITY_RULES:
+        try:
+            pert.priorities = None
+            s_out = pert.calculateSerialScheduleWithResources(priority_rule=rule)
+            serial_durations[rule] = s_out['scheduled_duration'] - 2
+
+            pert.priorities = None
+            p_out = pert.calculateScheduleWithResources(
+                sgs='max_use_res_ranked', priority_rule=rule
+            )
+            parallel_durations[rule] = p_out['scheduled_duration'] - 2
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Rule '%s' skipped in baseline: %s", rule, exc)
+
+    best_serial   = min(serial_durations.values(),   default=float('inf'))
+    best_parallel = min(parallel_durations.values(), default=float('inf'))
+    best_rule_overall = min(best_serial, best_parallel)
+
+    if verbose:
+        print("Priority rule baseline durations:")
+        print(f"  {'Rule':<22} {'Serial (h)':>12} {'Parallel (h)':>14}")
+        print("  " + "-" * 50)
+        for rule in ALL_PRIORITY_RULES:
+            s = serial_durations.get(rule, float('nan'))
+            p = parallel_durations.get(rule, float('nan'))
+            print(f"  {rule:<22} {s:>12.2f} {p:>14.2f}")
+        print()
+
+    # ── Run ALNS ─────────────────────────────────────────────────────────────
+    alns = RCPSPAdaptiveLNS(
+        pert,
+        n_iter=n_iter,
+        destroy_fraction=destroy_fraction,
+        theta=theta,
+        seg_length=seg_length,
+        seed=seed,
+        accept=accept,
+        destroy_ops=destroy_ops,
+        repair_ops=repair_ops,
+        verbose=verbose,
+    )
+    best_state, log = alns.run()
+
+    # ── Report ───────────────────────────────────────────────────────────────
+    best_alns = log['best_duration']
+    best_activity_list = alns.get_best_activity_list(best_state)
+
+    print(f"{'─' * 60}")
+    print(f"  CPM duration (unconstrained)  : {cpm_duration:.2f} h")
+    print(f"  Best serial SGS  (all rules)  : {best_serial:.2f} h")
+    print(f"  Best parallel SGS (all rules) : {best_parallel:.2f} h")
+    print(f"  ALNS initial solution         : {log['initial_duration']:.2f} h")
+    print(f"  Best ALNS duration            : {best_alns:.2f} h")
+    print(f"  Improvement over best seed    : {best_rule_overall - best_alns:.2f} h")
+    print(f"  ALNS internal improvement     : {log['improvement']:.2f} h")
+    print(f"{'─' * 60}")
+    print(f"  Best activity list (first 10) : {best_activity_list[:10]}")
+    print()
+
+    return {
+        'case':               case_name,
+        'n_activities':       n_activities,
+        'cpm_duration':       cpm_duration,
+        'best_serial_seed':   best_serial,
+        'best_parallel_seed': best_parallel,
+        'best_alns':          best_alns,
+        'improvement':        best_rule_overall - best_alns,
+    }
+
+
+def main() -> None:
+    """Run the ALNS on all benchmark cases and print a summary table."""
+    results = []
+    for case_name, json_file in CASES:
+        result = run_alns_case(
+            case_name=case_name,
+            json_file=json_file,
+            n_iter=2000,
+            destroy_fraction=0.25,
+            theta=0.8,
+            seg_length=100,
+            seed=42,
+            accept='hill_climbing',
+            verbose=True,
+        )
+        results.append(result)
+
+    # ── Summary table ─────────────────────────────────────────────────────────
+    print("\n" + "=" * 85)
+    print(
+        "SUMMARY — ALNS (Activity List, most_mobile + segment + random destroy, "
+        "random + greedy repair, Serial SGS)"
+    )
+    print("=" * 85)
+    print(
+        f"  {'Case':<8} {'N':>6} {'CPM (h)':>10} "
+        f"{'Best Serial':>13} {'Best Parallel':>14} {'Best ALNS':>10} {'Δ (h)':>8}"
+    )
+    print("  " + "-" * 72)
+    for r in results:
+        print(
+            f"  {r['case']:<8} {r['n_activities']:>6} {r['cpm_duration']:>10.2f} "
+            f"{r['best_serial_seed']:>13.2f} {r['best_parallel_seed']:>14.2f} "
+            f"{r['best_alns']:>10.2f} {r['improvement']:>8.2f}"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CPM/rcpsp_alns.py
+++ b/src/CPM/rcpsp_alns.py
@@ -1,0 +1,759 @@
+# Copyright 2020, Battelle Energy Alliance, LLC
+# ALL RIGHTS RESERVED
+"""
+rcpsp_alns.py — Adaptive Large Neighbourhood Search for RCPSP
+
+Implements ALNS for the Resource-Constrained Project Scheduling Problem using
+the `alns` library (Wouda & Lan, 2023).  Solution states use the Activity List
+representation (precedence-feasible orderings) and the serial SGS decoder from
+``pert.calculateSerialScheduleWithResources``, matching the fitness function
+used in ``ga.py``.
+
+References
+----------
+Wouda, N.A., and L. Lan (2023).  ALNS: a Python implementation.
+  *Journal of Open Source Software*, 8(81): 5028.
+
+Shaw, P. (1998). Using constraint programming and local search methods to
+  solve vehicle routing problems. *CP*, 417–431.
+
+Valls, V., Ballestin, F., and Quintanilla, S. (2005).  Justification and
+  RCPSP: A technique that pays.  *European Journal of Operational Research*,
+  165(2): 375–386.
+
+Solution Representation
+-----------------------
+An ``RCPSPState`` wraps a **precedence-feasible activity list** (a list of
+``Activity`` objects in scheduling order) plus an ``unscheduled`` list that
+holds activities temporarily removed by a destroy operator.  A state is
+*complete* when ``unscheduled`` is empty; only complete states expose a valid
+``objective()`` value.
+
+Destroy Operators
+-----------------
+``most_mobile``
+    Remove the top-k activities by total float (slack = LF − EF from the
+    unconstrained CPM solution).  Highly mobile activities are the most
+    interchangeable and their removal creates the widest repair space.
+
+``segment``
+    Remove a randomly located contiguous block of k activities from the
+    non-dummy part of the ordering.  Disrupts local neighbourhood structure
+    while keeping the rest of the sequence intact.
+
+``random``
+    Remove k activities chosen uniformly at random from non-dummy activities.
+    Provides unbiased exploration when the other operators are overspecialised.
+
+Repair Operators
+----------------
+``random_insert``
+    Re-insert each unscheduled activity at a uniformly random position within
+    its feasible window [lo, hi], where lo = 1 + max(position of predecessors
+    in current partial ordering) and hi = min(position of successors).
+    Activities are processed in topological order so that predecessors are
+    inserted before their dependents.
+
+``greedy_insert``
+    Same as ``random_insert`` but always chooses position ``lo`` (earliest
+    feasible), producing a left-justified, greedy repair.  Tends to reduce
+    makespan at the cost of population diversity.
+
+Acceptance Criteria
+-------------------
+``hill_climbing``
+    Only accept candidate solutions that strictly improve the current solution.
+    Zero-temperature behaviour; fastest convergence but susceptible to local
+    optima.
+
+``record_to_record``
+    Accept if the candidate's objective is within a linearly decreasing
+    threshold of the best-known solution (Record-to-Record Travel, Dueck 1993).
+    Auto-fitted via ``RecordToRecordTravel.autofit``.
+
+``simulated_annealing``
+    Accept with probability exp(−Δ/T) where T decreases geometrically from
+    ``start_temperature`` to ``end_temperature`` over ``n_iter`` iterations.
+
+Operator Selection
+------------------
+``SegmentedRouletteWheel`` from the `alns` library partitions iterations into
+fixed-length segments (default 100), tracks cumulative reward scores per
+operator within each segment, then updates operator weights using a convex
+combination with decay factor θ at segment boundaries.  Reward scores follow
+the standard ALNS convention: [w_best, w_better, w_accepted, w_rejected].
+
+Requirements
+------------
+    pip install alns
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+try:
+    from alns import ALNS
+    from alns.accept import HillClimbing, SimulatedAnnealing, RecordToRecordTravel
+    from alns.select import SegmentedRouletteWheel
+    from alns.stop import MaxIterations
+except ImportError as _alns_err:
+    raise ImportError(
+        "alns is required by rcpsp_alns.py.  Install it with:  pip install alns"
+    ) from _alns_err
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Priority rules used to seed the initial solution (best of these is chosen).
+# ---------------------------------------------------------------------------
+SEED_PRIORITY_RULES: List[str] = [
+    'es', 'ef', 'ls', 'lf', 'duration', 'random',
+    'mts', 'mtp', 'grpw', 'grd', 'rr', 'avgrr',
+    'maxrr', 'minrr', 'irsm', 'wcs', 'acs',
+    'mehh_8000_b', 'mehh_3375_b', 'mehh_1000_b', 'mehh_125_b', 'gphh_b',
+]
+
+# Default ALNS reward weights: [new best, better than current, accepted, rejected]
+DEFAULT_WEIGHTS: List[int] = [25, 5, 1, 0]
+
+
+# =========================================================================== #
+# Solution State                                                               #
+# =========================================================================== #
+
+class RCPSPState:
+    """
+    ALNS solution state for the RCPSP.
+
+    A *complete* state holds a precedence-feasible ordering of **all**
+    activities (``unscheduled`` is empty).  A *destroyed* state has some
+    activities moved to ``unscheduled`` and cannot be evaluated.
+
+    Parameters
+    ----------
+    pert : Pert
+        Fully initialised ``Pert`` object shared across all states.
+    ordering : list of Activity
+        Precedence-feasible ordering of scheduled activities.
+    unscheduled : list of Activity, optional
+        Activities not yet in the ordering (empty for complete states).
+    """
+
+    def __init__(
+        self,
+        pert: Any,
+        ordering: List[Any],
+        unscheduled: Optional[List[Any]] = None,
+    ) -> None:
+        self._pert = pert
+        self.ordering: List[Any] = list(ordering)
+        self.unscheduled: List[Any] = list(unscheduled) if unscheduled else []
+        self._obj_cache: Optional[float] = None
+
+    # ------------------------------------------------------------------ #
+
+    def objective(self) -> float:
+        """
+        Evaluate the schedule via Serial SGS and return the project duration.
+
+        Raises ``ValueError`` if the state is incomplete (destroyed).
+        Result is cached — subsequent calls are free.
+        """
+        if self.unscheduled:
+            raise ValueError(
+                "Cannot evaluate an incomplete (destroyed) state: "
+                f"{len(self.unscheduled)} activities still unscheduled."
+            )
+        if self._obj_cache is None:
+            out = self._pert.calculateSerialScheduleWithResources(
+                _ordered=self.ordering
+            )
+            self._obj_cache = float(out['scheduled_duration'] - 2)
+        return self._obj_cache
+
+    # ------------------------------------------------------------------ #
+
+    def invalidate_cache(self) -> None:
+        """Mark the cached objective as stale (call after modifying ``ordering``)."""
+        self._obj_cache = None
+
+    def copy(self) -> 'RCPSPState':
+        """Return a lightweight copy suitable for use in destroy/repair operators."""
+        s: RCPSPState = object.__new__(RCPSPState)
+        s._pert = self._pert          # pylint: disable=protected-access
+        s.ordering = list(self.ordering)
+        s.unscheduled = list(self.unscheduled)
+        s._obj_cache = self._obj_cache  # pylint: disable=protected-access
+        return s
+
+    def __repr__(self) -> str:
+        obj = f"{self._obj_cache:.2f}" if self._obj_cache is not None else "?"
+        return (
+            f"RCPSPState(obj={obj}, "
+            f"scheduled={len(self.ordering)}, unscheduled={len(self.unscheduled)})"
+        )
+
+
+# =========================================================================== #
+# ALNS Optimiser                                                               #
+# =========================================================================== #
+
+class RCPSPAdaptiveLNS:
+    """
+    Adaptive Large Neighbourhood Search optimiser for RCPSP.
+
+    Uses the Activity List representation with the Serial SGS decoder
+    (``pert.calculateSerialScheduleWithResources``).  Operator selection is
+    handled by ``SegmentedRouletteWheel`` from the `alns` library so the
+    algorithm automatically learns which destroy/repair combinations work best.
+
+    Parameters
+    ----------
+    pert : Pert
+        A fully initialised ``Pert`` object with ``generateInfo()`` called.
+    n_iter : int
+        Total number of ALNS iterations.
+    destroy_fraction : float
+        Fraction of non-dummy activities removed per destroy step (0, 1).
+        E.g. ``0.25`` removes 25 % of activities at each iteration.
+    weights : list of int, optional
+        Reward scores ``[w_best, w_better, w_accepted, w_rejected]`` for the
+        ``SegmentedRouletteWheel``.  Defaults to ``[25, 5, 1, 0]``.
+    theta : float
+        Segment-decay factor for ``SegmentedRouletteWheel`` (0, 1).
+        Higher values retain more historical weight across segments.
+    seg_length : int
+        Number of iterations per weight-update segment.
+    seed : int
+        RNG seed for reproducibility.
+    accept : str
+        Acceptance criterion.  Choices:
+
+        * ``'hill_climbing'``        — only accept improvements (default)
+        * ``'record_to_record'``     — accept within a decreasing gap of best
+        * ``'simulated_annealing'``  — temperature-based acceptance
+    rrt_percent_gap : float
+        For ``'record_to_record'``: initial tolerance as a fraction of the
+        initial objective (e.g. ``0.02`` = 2 %).  Decreases linearly to 0.
+    sa_start_temp : float, optional
+        For ``'simulated_annealing'``: start temperature.  Defaults to
+        ``0.05 * initial_objective``.
+    sa_end_temp : float, optional
+        For ``'simulated_annealing'``: end temperature.  Defaults to
+        ``0.001 * initial_objective``.
+    destroy_ops : list of str, optional
+        Subset of destroy operators to use.  Defaults to all three:
+        ``['most_mobile', 'segment', 'random']``.
+    repair_ops : list of str, optional
+        Subset of repair operators to use.  Defaults to both:
+        ``['random_insert', 'greedy_insert']``.
+    verbose : bool
+        Print seeding table, per-run summary, and operator usage stats.
+    """
+
+    _DESTROY_METHODS: Dict[str, str] = {
+        'most_mobile': '_destroy_most_mobile',
+        'segment':     '_destroy_segment',
+        'random':      '_destroy_random',
+    }
+    _REPAIR_METHODS: Dict[str, str] = {
+        'random_insert':  '_repair_random_insert',
+        'greedy_insert':  '_repair_greedy_insert',
+    }
+
+    def __init__(
+        self,
+        pert: Any,
+        n_iter: int = 1000,
+        destroy_fraction: float = 0.25,
+        weights: Optional[List[int]] = None,
+        theta: float = 0.8,
+        seg_length: int = 100,
+        seed: int = 42,
+        accept: str = 'hill_climbing',
+        rrt_percent_gap: float = 0.02,
+        sa_start_temp: Optional[float] = None,
+        sa_end_temp: Optional[float] = None,
+        destroy_ops: Optional[List[str]] = None,
+        repair_ops: Optional[List[str]] = None,
+        verbose: bool = True,
+    ) -> None:
+        destroy_ops = destroy_ops or list(self._DESTROY_METHODS)
+        repair_ops  = repair_ops  or list(self._REPAIR_METHODS)
+
+        for op in destroy_ops:
+            if op not in self._DESTROY_METHODS:
+                raise ValueError(
+                    f"Unknown destroy operator '{op}'. "
+                    f"Choose from: {list(self._DESTROY_METHODS)}"
+                )
+        for op in repair_ops:
+            if op not in self._REPAIR_METHODS:
+                raise ValueError(
+                    f"Unknown repair operator '{op}'. "
+                    f"Choose from: {list(self._REPAIR_METHODS)}"
+                )
+        if accept not in ('hill_climbing', 'record_to_record', 'simulated_annealing'):
+            raise ValueError(
+                f"Unknown accept criterion '{accept}'. "
+                "Choose from: 'hill_climbing', 'record_to_record', "
+                "'simulated_annealing'."
+            )
+
+        self.pert = pert
+        self.n_iter = n_iter
+        self.destroy_fraction = destroy_fraction
+        self.weights = weights or list(DEFAULT_WEIGHTS)
+        self.theta = theta
+        self.seg_length = seg_length
+        self.accept_name = accept
+        self.rrt_percent_gap = rrt_percent_gap
+        self.sa_start_temp = sa_start_temp
+        self.sa_end_temp = sa_end_temp
+        self.destroy_ops = destroy_ops
+        self.repair_ops = repair_ops
+        self.verbose = verbose
+
+        self._rng = np.random.default_rng(seed)
+
+        # Dummy activity handles
+        self._start: Any = pert.startActivity
+        self._end: Any = pert.endActivity
+        self._dummies = {a for a in (self._start, self._end) if a is not None}
+
+        # Read total float directly from pert.infoDict["slack"] which is
+        # already computed by pert.calculateSlack() as lf − ef.
+        self._slack: Dict[Any, float] = {
+            act: info.get('slack', 0.0)
+            for act, info in pert.infoDict.items()
+            if info is not None
+        }
+
+        # Precompute transitive successors for each activity.
+        # Used by _insert_feasible to compute a correct hi bound even when
+        # all direct successors of an activity have been removed by destroy.
+        all_activities = [a for a in pert.infoDict if pert.infoDict[a] is not None]
+        topo_order = self._topo_sort(all_activities)
+        self._trans_successors: Dict[Any, set] = {}
+        for a in reversed(topo_order):
+            direct: set = set(pert.forwardDict.get(a, []))
+            trans: set = set()
+            for s in direct:
+                trans |= self._trans_successors.get(s, set())
+            self._trans_successors[a] = direct | trans
+
+    # ====================================================================== #
+    # Initial solution helpers                                                 #
+    # ====================================================================== #
+
+    def _ordering_from_rule(self, rule: str) -> List[Any]:
+        """Return a precedence-feasible Activity list from a named priority rule."""
+        all_acts = list(self.pert.forwardDict.keys())
+        raw = self.pert.priority_calculation(all_acts, priority_rule=rule)
+        if raw and isinstance(raw[0], tuple):
+            return [a for (a, _, _) in raw]
+        return list(raw)
+
+    def _create_initial_solution(self) -> Tuple['RCPSPState', Dict[str, float]]:
+        """
+        Evaluate all seed priority rules and return the best as initial state.
+
+        Returns
+        -------
+        best_state : RCPSPState
+        seed_info : dict mapping rule name → duration (h)
+        """
+        seed_info: Dict[str, float] = {}
+        best_state: Optional[RCPSPState] = None
+        best_dur = float('inf')
+
+        for rule in SEED_PRIORITY_RULES:
+            try:
+                self.pert.priorities = None
+                ordering = self._ordering_from_rule(rule)
+                state = RCPSPState(self.pert, ordering)
+                dur = state.objective()
+                seed_info[rule] = dur
+                if dur < best_dur:
+                    best_dur = dur
+                    best_state = state.copy()
+            except (ValueError, KeyError, RuntimeError) as exc:
+                logger.debug("Seed rule '%s' failed: %s", rule, exc)
+
+        if best_state is None:
+            ordering = self._ordering_from_rule('random')
+            best_state = RCPSPState(self.pert, ordering)
+
+        return best_state, seed_info
+
+    # ====================================================================== #
+    # Internal helpers                                                         #
+    # ====================================================================== #
+
+    def _non_dummy(self, ordering: List[Any]) -> List[Any]:
+        """Return only non-dummy activities from the ordering."""
+        return [a for a in ordering if a not in self._dummies]
+
+    def _topo_sort(self, activities: List[Any]) -> List[Any]:
+        """
+        Return ``activities`` in topological order (predecessors first).
+
+        Uses iterative DFS to avoid recursion-limit issues on large instances.
+        Only considers predecessor edges among the supplied activity set.
+        """
+        act_set = set(activities)
+        result: List[Any] = []
+        visited: set = set()
+
+        def dfs(a: Any) -> None:
+            stack = [(a, False)]
+            while stack:
+                node, processed = stack.pop()
+                if processed:
+                    if node not in visited:
+                        visited.add(node)
+                        result.append(node)
+                    continue
+                if node in visited or node not in act_set:
+                    continue
+                stack.append((node, True))
+                for pred in self.pert.backwardDict.get(node, []):
+                    if pred in act_set and pred not in visited:
+                        stack.append((pred, False))
+
+        for a in activities:
+            dfs(a)
+
+        return result
+
+    def _insert_feasible(
+        self,
+        act: Any,
+        ordering: List[Any],
+        rng: Optional[np.random.Generator],
+        greedy: bool,
+    ) -> None:
+        """
+        Insert ``act`` into ``ordering`` (in-place) at a feasible position.
+
+        The feasible window [lo, hi] is:
+          lo = 1 + max position of predecessors of ``act`` in ordering
+               (0 if no predecessors currently in ordering)
+          hi = min position of successors of ``act`` in ordering
+               (len(ordering) if no successors currently in ordering)
+
+        Insertion at position ``p`` places ``act`` before the element
+        currently at index ``p``.  ``greedy=True`` always inserts at ``lo``;
+        otherwise a uniform random position in [lo, hi] is used.
+        """
+        pos_of: Dict[Any, int] = {a: p for p, a in enumerate(ordering)}
+
+        preds = [pr for pr in self.pert.backwardDict.get(act, []) if pr in pos_of]
+        lo = (max(pos_of[pr] for pr in preds) + 1) if preds else 0
+
+        all_succs = self._trans_successors.get(act, set())
+        succs = [sc for sc in ordering if sc in all_succs]
+        hi = (min(pos_of[sc] for sc in succs)) if succs else len(ordering)
+
+        # Safety clamp — should not trigger on valid instances
+        lo = max(0, lo)
+        hi = max(lo, min(len(ordering), hi))
+
+        if greedy or rng is None:
+            pos = lo
+        else:
+            pos = int(rng.integers(lo, hi + 1))
+
+        ordering.insert(pos, act)
+
+    # ====================================================================== #
+    # Destroy operators                                                        #
+    # ====================================================================== #
+
+    def _destroy_most_mobile(
+        self, state: 'RCPSPState', _rng: np.random.Generator
+    ) -> 'RCPSPState':
+        """
+        Remove the k most mobile (highest total float) non-dummy activities.
+
+        Total float is taken from the unconstrained CPM solution stored in
+        ``pert.infoDict`` and precomputed at construction time, so this
+        operator costs O(n log n) per call.  The RNG argument is accepted to
+        match the ALNS operator protocol but is not used (selection is
+        deterministic given the precomputed slack values).
+        """
+        destroyed = state.copy()
+        non_dummy = self._non_dummy(destroyed.ordering)
+        if not non_dummy:
+            return destroyed
+
+        k = max(1, int(len(non_dummy) * self.destroy_fraction))
+        to_remove = sorted(
+            non_dummy, key=lambda a: self._slack.get(a, 0.0), reverse=True
+        )[:k]
+        remove_set = set(to_remove)
+
+        destroyed.ordering = [a for a in destroyed.ordering if a not in remove_set]
+        destroyed.unscheduled = to_remove
+        destroyed.invalidate_cache()
+        return destroyed
+
+    def _destroy_segment(
+        self, state: 'RCPSPState', rng: np.random.Generator
+    ) -> 'RCPSPState':
+        """
+        Remove a random contiguous segment of k non-dummy activities.
+
+        A starting index within the non-dummy positions is drawn uniformly;
+        the following k positions are removed together, preserving contiguity
+        in the original ordering.
+        """
+        destroyed = state.copy()
+        non_dummy_positions = [
+            p for p, a in enumerate(destroyed.ordering) if a not in self._dummies
+        ]
+        if not non_dummy_positions:
+            return destroyed
+
+        n_nd = len(non_dummy_positions)
+        k = max(1, int(n_nd * self.destroy_fraction))
+        k = min(k, n_nd)
+
+        start_idx = int(rng.integers(0, n_nd - k + 1))
+        remove_positions = set(non_dummy_positions[start_idx: start_idx + k])
+
+        to_remove = [destroyed.ordering[p] for p in sorted(remove_positions)]
+        destroyed.ordering = [
+            a for p, a in enumerate(destroyed.ordering) if p not in remove_positions
+        ]
+        destroyed.unscheduled = to_remove
+        destroyed.invalidate_cache()
+        return destroyed
+
+    def _destroy_random(
+        self, state: 'RCPSPState', rng: np.random.Generator
+    ) -> 'RCPSPState':
+        """
+        Remove k randomly chosen non-dummy activities (uniform, without replacement).
+
+        Provides unbiased diversification when the other operators have
+        converged to a sub-region of the search space.
+        """
+        destroyed = state.copy()
+        non_dummy = self._non_dummy(destroyed.ordering)
+        if not non_dummy:
+            return destroyed
+
+        k = max(1, int(len(non_dummy) * self.destroy_fraction))
+        k = min(k, len(non_dummy))
+        indices = rng.choice(len(non_dummy), size=k, replace=False)
+        remove_set = {non_dummy[i] for i in indices}
+
+        destroyed.ordering = [a for a in destroyed.ordering if a not in remove_set]
+        destroyed.unscheduled = [a for a in non_dummy if a in remove_set]
+        destroyed.invalidate_cache()
+        return destroyed
+
+    # ====================================================================== #
+    # Repair operators                                                         #
+    # ====================================================================== #
+
+    def _repair_random_insert(
+        self, state: 'RCPSPState', rng: np.random.Generator
+    ) -> 'RCPSPState':
+        """
+        Re-insert unscheduled activities at uniformly random feasible positions.
+
+        Activities are processed in topological order (predecessors first) so
+        that each insertion finds its correct feasible window.
+        """
+        repaired = state.copy()
+        to_insert = self._topo_sort(repaired.unscheduled)
+        repaired.unscheduled = []
+
+        for act in to_insert:
+            self._insert_feasible(act, repaired.ordering, rng, greedy=False)
+
+        repaired.invalidate_cache()
+        return repaired
+
+    def _repair_greedy_insert(
+        self, state: 'RCPSPState', rng: np.random.Generator
+    ) -> 'RCPSPState':
+        """
+        Re-insert unscheduled activities at the earliest feasible position (lo).
+
+        Produces a left-justified (greedy) insertion that tends to reduce
+        makespan at the cost of diversity.
+        """
+        repaired = state.copy()
+        to_insert = self._topo_sort(repaired.unscheduled)
+        repaired.unscheduled = []
+
+        for act in to_insert:
+            self._insert_feasible(act, repaired.ordering, rng, greedy=True)
+
+        repaired.invalidate_cache()
+        return repaired
+
+    # ====================================================================== #
+    # Main optimisation loop                                                   #
+    # ====================================================================== #
+
+    def run(self) -> Tuple['RCPSPState', Dict[str, Any]]:
+        """
+        Execute the ALNS algorithm.
+
+        Workflow
+        --------
+        1. Build an initial solution by evaluating all seed priority rules and
+           selecting the best ordering.
+        2. Configure the ``ALNS`` engine with the chosen destroy and repair
+           operators, ``SegmentedRouletteWheel`` selection, the configured
+           acceptance criterion, and ``MaxIterations`` stopping rule.
+        3. Run ``alns.iterate`` and return the best state found.
+
+        Returns
+        -------
+        best_state : RCPSPState
+            Best complete solution found.
+        log : dict
+            Summary with keys:
+            ``initial_duration``, ``best_duration``, ``improvement``,
+            ``destroy_counts``, ``repair_counts``.
+        """
+        # ── Initial solution ────────────────────────────────────────────────
+        init_state, seed_info = self._create_initial_solution()
+        init_dur = init_state.objective()
+
+        if self.verbose:
+            if seed_info:
+                print(
+                    f"\nInitial seeding ({len(seed_info)} rules)  |  "
+                    f"best = {min(seed_info.values()):.2f} h\n"
+                )
+                print(f"  {'Rule':<22} {'Duration (h)':>14}")
+                print("  " + "-" * 38)
+                for rule, dur in seed_info.items():
+                    print(f"  {rule:<22} {dur:>14.2f}")
+            print(
+                f"\nRunning ALNS  "
+                f"destroy={self.destroy_ops}  "
+                f"repair={self.repair_ops}  "
+                f"accept={self.accept_name!r}  "
+                f"n_iter={self.n_iter}\n"
+                f"  Initial objective : {init_dur:.2f} h"
+            )
+
+        # ── ALNS engine setup ───────────────────────────────────────────────
+        alns_engine = ALNS(self._rng)
+
+        for op_name in self.destroy_ops:
+            alns_engine.add_destroy_operator(
+                getattr(self, self._DESTROY_METHODS[op_name]), name=op_name
+            )
+        for op_name in self.repair_ops:
+            alns_engine.add_repair_operator(
+                getattr(self, self._REPAIR_METHODS[op_name]), name=op_name
+            )
+
+        select = SegmentedRouletteWheel(
+            self.weights, self.theta, self.seg_length,
+            len(self.destroy_ops), len(self.repair_ops),
+        )
+
+        # ── Acceptance criterion ────────────────────────────────────────────
+        if self.accept_name == 'hill_climbing':
+            accept = HillClimbing()
+
+        elif self.accept_name == 'record_to_record':
+            # autofit(init_obj, start_gap, end_gap, num_iters) — linear decay
+            accept = RecordToRecordTravel.autofit(
+                init_dur, self.rrt_percent_gap, 0.0, self.n_iter
+            )
+
+        elif self.accept_name == 'simulated_annealing':
+            # autofit(init_obj, worse, accept_prob, num_iters) — exponential cooling
+            # Accept solutions up to 5% worse with probability 0.5 initially.
+            accept = SimulatedAnnealing.autofit(init_dur, 0.05, 0.5, self.n_iter)
+
+        else:
+            accept = HillClimbing()
+
+        stop = MaxIterations(self.n_iter)
+
+        # ── Run ─────────────────────────────────────────────────────────────
+        result = alns_engine.iterate(init_state, select, accept, stop)
+        best_state: RCPSPState = result.best_state
+        best_dur = best_state.objective()
+        stats = result.statistics
+
+        if self.verbose:
+            print(f"  Best found        : {best_dur:.2f} h")
+            print(f"  Improvement       : {init_dur - best_dur:.2f} h\n")
+            print("  Destroy operator usage  [best / better / accepted / rejected]:")
+            for op, counts in stats.destroy_operator_counts.items():
+                print(f"    {op:<20} {counts}")
+            print("  Repair operator usage   [best / better / accepted / rejected]:")
+            for op, counts in stats.repair_operator_counts.items():
+                print(f"    {op:<20} {counts}")
+            print()
+
+        logger.info(
+            "ALNS finished | best = %.2f h | init = %.2f h | iterations = %d",
+            best_dur, init_dur, self.n_iter,
+        )
+
+        log: Dict[str, Any] = {
+            'initial_duration': init_dur,
+            'best_duration':    best_dur,
+            'improvement':      init_dur - best_dur,
+            'destroy_counts':   dict(stats.destroy_operator_counts),
+            'repair_counts':    dict(stats.repair_operator_counts),
+        }
+        return best_state, log
+
+    # ====================================================================== #
+    # Result helpers                                                           #
+    # ====================================================================== #
+
+    def get_best_schedule(self, best_state: 'RCPSPState') -> Dict[str, Any]:
+        """
+        Decode the best state and return the full schedule result dict.
+
+        Calls ``calculateSerialScheduleWithResources`` with the best activity
+        ordering so the ``Pert`` object is left in the state of the best
+        found schedule (Gantt chart, constrained chain, etc. are accessible).
+
+        Parameters
+        ----------
+        best_state : RCPSPState
+            As returned by ``run()``.
+
+        Returns
+        -------
+        dict
+            Same keys as ``calculateSerialScheduleWithResources``.
+        """
+        return self.pert.calculateSerialScheduleWithResources(
+            _ordered=best_state.ordering
+        )
+
+    def get_best_activity_list(self, best_state: 'RCPSPState') -> List[str]:
+        """
+        Return the best ordering as a human-readable list of activity names.
+
+        Parameters
+        ----------
+        best_state : RCPSPState
+            As returned by ``run()``.
+
+        Returns
+        -------
+        list of str
+        """
+        return [a.returnName() for a in best_state.ordering]

--- a/tests/unit_tests/CPM/test_rcpsp_alns.py
+++ b/tests/unit_tests/CPM/test_rcpsp_alns.py
@@ -1,0 +1,861 @@
+"""
+test_rcpsp_alns.py — Unit tests for rcpsp_alns.py
+
+Tests are organized in six tiers:
+
+  1. RCPSPState tests
+       __init__, objective, invalidate_cache, copy, __repr__
+
+  2. Constructor tests
+       __init__ validation, operator maps, slack loading, dummy detection
+
+  3. Internal helper tests
+       _ordering_from_rule, _non_dummy, _topo_sort, _insert_feasible
+
+  4. Destroy operator tests
+       _destroy_most_mobile, _destroy_segment, _destroy_random
+
+  5. Repair operator tests
+       _repair_random_insert, _repair_greedy_insert
+
+  6. End-to-end run and result helper tests
+       run, get_best_schedule, get_best_activity_list
+
+Usage (from repo root):
+    pytest tests/unit_tests/CPM/test_rcpsp_alns.py -v
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# ── path setup ────────────────────────────────────────────────────────────────
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.CPM.pert import Pert                                      # noqa: E402
+from src.CPM.rcpsp_alns import (                                   # noqa: E402
+    RCPSPAdaptiveLNS, RCPSPState, SEED_PRIORITY_RULES,
+)
+
+# ── shared fixtures ───────────────────────────────────────────────────────────
+CPM_DIR   = REPO_ROOT / 'src' / 'CPM'
+JSON_PATH = str(CPM_DIR / 'example_10.json')
+SCHEMA    = str(CPM_DIR / 'outage_schema.json')
+
+
+@pytest.fixture(scope='module')
+def pert():
+    """Fully initialised Pert object for example_10.json (12 activities)."""
+    p = Pert.from_json_file(JSON_PATH, schema_path=SCHEMA)
+    p.generateInfo()
+    return p
+
+
+@pytest.fixture(scope='module')
+def alns(pert):
+    """ALNS instance with minimal settings for fast tests."""
+    return RCPSPAdaptiveLNS(
+        pert,
+        n_iter=10,
+        destroy_fraction=0.3,
+        seed=0,
+        verbose=False,
+    )
+
+
+@pytest.fixture(scope='module')
+def init_state(alns):
+    """A complete initial state built from the best seed rule."""
+    state, _ = alns._create_initial_solution()
+    return state
+
+
+def _is_precedence_feasible(ordering, backward_dict):
+    """Return True if every predecessor appears before its successor."""
+    pos = {a: i for i, a in enumerate(ordering)}
+    for act, preds in backward_dict.items():
+        if act not in pos:
+            continue
+        for pred in preds:
+            if pred in pos and pos[pred] >= pos[act]:
+                return False
+    return True
+
+
+# =============================================================================
+# 1. RCPSPState
+# =============================================================================
+
+class TestRCPSPState:
+
+    def test_init_complete_state(self, pert):
+        """A state with no unscheduled list defaults to empty."""
+        ordering = list(pert.forwardDict.keys())
+        state = RCPSPState(pert, ordering)
+        assert state.ordering == ordering
+        assert state.unscheduled == []
+        assert state._obj_cache is None
+
+    def test_init_with_unscheduled(self, pert):
+        """Unscheduled activities are stored separately."""
+        acts = list(pert.forwardDict.keys())
+        scheduled, unscheduled = acts[:-2], acts[-2:]
+        state = RCPSPState(pert, scheduled, unscheduled)
+        assert state.ordering == scheduled
+        assert state.unscheduled == unscheduled
+
+    def test_objective_raises_for_incomplete_state(self, pert):
+        """Calling objective() on a destroyed state must raise ValueError."""
+        acts = list(pert.forwardDict.keys())
+        state = RCPSPState(pert, acts[:-2], acts[-2:])
+        with pytest.raises(ValueError, match="incomplete"):
+            state.objective()
+
+    def test_objective_returns_positive_float(self, init_state):
+        """Objective must return a positive numeric value."""
+        dur = init_state.objective()
+        assert isinstance(dur, float)
+        assert dur > 0
+
+    def test_objective_is_cached(self, init_state):
+        """Second call must return the same object without re-evaluating."""
+        _ = init_state.objective()           # populate cache
+        cached = init_state._obj_cache
+        assert cached is not None
+        assert init_state.objective() == cached
+
+    def test_invalidate_cache_clears_value(self, pert, alns):
+        """After invalidate_cache() the next objective() call must recompute."""
+        state, _ = alns._create_initial_solution()
+        _ = state.objective()                # populate cache
+        assert state._obj_cache is not None
+        state.invalidate_cache()
+        assert state._obj_cache is None
+
+    def test_copy_is_different_object(self, init_state):
+        """copy() must return a new RCPSPState instance."""
+        copy = init_state.copy()
+        assert copy is not init_state
+
+    def test_copy_ordering_is_independent(self, init_state):
+        """Mutating the copy's ordering must not affect the original."""
+        copy = init_state.copy()
+        original_first = init_state.ordering[0]
+        copy.ordering[0] = None          # corrupt the copy
+        assert init_state.ordering[0] is original_first
+
+    def test_copy_unscheduled_is_independent(self, pert):
+        """Mutating copy's unscheduled must not affect the original."""
+        acts = list(pert.forwardDict.keys())
+        state = RCPSPState(pert, acts[:-1], acts[-1:])
+        copy = state.copy()
+        copy.unscheduled.clear()
+        assert len(state.unscheduled) == 1
+
+    def test_copy_preserves_cached_objective(self, init_state):
+        """copy() should carry over any already-computed objective cache."""
+        _ = init_state.objective()
+        copy = init_state.copy()
+        assert copy._obj_cache == init_state._obj_cache
+
+    def test_repr_shows_unknown_obj_before_evaluation(self, pert):
+        """Before objective() is called, repr must show '?'."""
+        state = RCPSPState(pert, list(pert.forwardDict.keys()))
+        assert "?" in repr(state)
+
+    def test_repr_shows_numeric_obj_after_evaluation(self, init_state):
+        """After objective() is called, repr must show a numeric value."""
+        _ = init_state.objective()
+        r = repr(init_state)
+        assert "?" not in r
+        assert "obj=" in r
+
+
+# =============================================================================
+# 2. Constructor and initialisation
+# =============================================================================
+
+class TestConstructor:
+
+    def test_seed_priority_rules_match_ga(self):
+        """SEED_PRIORITY_RULES must cover the full set from ga.py."""
+        from src.CPM.ga import PRIORITY_RULES as GA_RULES
+        assert set(SEED_PRIORITY_RULES) == set(GA_RULES)
+
+    def test_slack_loaded_from_infodict(self, pert, alns):
+        """_slack values must equal pert.infoDict[act]['slack'] exactly."""
+        for act, slack_val in alns._slack.items():
+            expected = pert.infoDict[act].get('slack', 0.0)
+            assert slack_val == expected, (
+                f"{act.returnName()}: stored {slack_val} != infoDict {expected}"
+            )
+
+    def test_slack_not_recomputed(self, pert, alns):
+        """Slack must be lf-ef as computed by pert.calculateSlack(), not lf-ef recomputed here."""
+        for act, slack_val in alns._slack.items():
+            info = pert.infoDict[act]
+            lf_ef = info.get('lf', 0.0) - info.get('ef', 0.0)
+            assert abs(slack_val - lf_ef) < 1e-9
+
+    def test_dummies_identified(self, pert, alns):
+        """_dummies must contain startActivity and endActivity (when present)."""
+        if pert.startActivity:
+            assert pert.startActivity in alns._dummies
+        if pert.endActivity:
+            assert pert.endActivity in alns._dummies
+
+    def test_destroy_method_map_complete(self):
+        """All documented destroy operators must be registered."""
+        assert set(RCPSPAdaptiveLNS._DESTROY_METHODS) == {
+            'most_mobile', 'segment', 'random'
+        }
+
+    def test_repair_method_map_complete(self):
+        """All documented repair operators must be registered."""
+        assert set(RCPSPAdaptiveLNS._REPAIR_METHODS) == {
+            'random_insert', 'greedy_insert'
+        }
+
+    def test_invalid_destroy_op_raises(self, pert):
+        """Unknown destroy operator name must raise ValueError at construction."""
+        with pytest.raises(ValueError, match="destroy"):
+            RCPSPAdaptiveLNS(pert, destroy_ops=['nonexistent'], verbose=False)
+
+    def test_invalid_repair_op_raises(self, pert):
+        """Unknown repair operator name must raise ValueError at construction."""
+        with pytest.raises(ValueError, match="repair"):
+            RCPSPAdaptiveLNS(pert, repair_ops=['nonexistent'], verbose=False)
+
+    def test_invalid_accept_raises(self, pert):
+        """Unknown acceptance criterion name must raise ValueError."""
+        with pytest.raises(ValueError, match="accept"):
+            RCPSPAdaptiveLNS(pert, accept='bogus', verbose=False)
+
+    def test_default_destroy_ops_all_three(self, alns):
+        """Default destroy_ops must include all three operators."""
+        assert set(alns.destroy_ops) == {'most_mobile', 'segment', 'random'}
+
+    def test_default_repair_ops_both(self, alns):
+        """Default repair_ops must include both repair operators."""
+        assert set(alns.repair_ops) == {'random_insert', 'greedy_insert'}
+
+    @pytest.mark.parametrize("accept", [
+        'hill_climbing', 'record_to_record', 'simulated_annealing'
+    ])
+    def test_all_accept_criteria_construct(self, pert, accept):
+        """All documented acceptance criteria must construct without error."""
+        a = RCPSPAdaptiveLNS(pert, n_iter=5, accept=accept, verbose=False)
+        assert a.accept_name == accept
+
+    def test_subset_destroy_ops(self, pert):
+        """Constructing with a subset of destroy operators must work."""
+        a = RCPSPAdaptiveLNS(
+            pert, destroy_ops=['random'], repair_ops=['greedy_insert'],
+            n_iter=5, verbose=False
+        )
+        assert a.destroy_ops == ['random']
+
+    def test_rng_is_numpy_generator(self, alns):
+        """_rng must be a numpy.random.Generator."""
+        assert isinstance(alns._rng, np.random.Generator)
+
+
+# =============================================================================
+# 3. Internal helpers
+# =============================================================================
+
+class TestOrderingFromRule:
+
+    @pytest.mark.parametrize("rule", ['es', 'lf', 'duration', 'mts', 'grpw'])
+    def test_named_rules_return_all_activities(self, alns, pert, rule):
+        """Every named rule must return all activities."""
+        ordering = alns._ordering_from_rule(rule)
+        assert set(ordering) == set(pert.forwardDict.keys())
+
+    def test_returns_activity_objects(self, alns, pert):
+        ordering = alns._ordering_from_rule('es')
+        assert len(ordering) == len(pert.forwardDict)
+        for act in ordering:
+            assert act in pert.forwardDict
+
+    def test_random_rule_returns_all_activities(self, alns, pert):
+        ordering = alns._ordering_from_rule('random')
+        assert set(ordering) == set(pert.forwardDict.keys())
+
+
+class TestNonDummy:
+
+    def test_excludes_start_activity(self, alns, pert):
+        ordering = list(pert.forwardDict.keys())
+        non_dummy = alns._non_dummy(ordering)
+        if pert.startActivity:
+            assert pert.startActivity not in non_dummy
+
+    def test_excludes_end_activity(self, alns, pert):
+        ordering = list(pert.forwardDict.keys())
+        non_dummy = alns._non_dummy(ordering)
+        if pert.endActivity:
+            assert pert.endActivity not in non_dummy
+
+    def test_non_dummy_plus_dummies_covers_all(self, alns, pert):
+        """Non-dummy + dummies must reconstruct the original ordering."""
+        ordering = list(pert.forwardDict.keys())
+        non_dummy = alns._non_dummy(ordering)
+        assert set(non_dummy) | alns._dummies == set(ordering)
+
+    def test_empty_ordering_returns_empty(self, alns):
+        assert alns._non_dummy([]) == []
+
+    def test_count_is_total_minus_dummies(self, alns, pert):
+        ordering = list(pert.forwardDict.keys())
+        non_dummy = alns._non_dummy(ordering)
+        n_dummies_in_ordering = sum(
+            1 for a in ordering if a in alns._dummies
+        )
+        assert len(non_dummy) == len(ordering) - n_dummies_in_ordering
+
+
+class TestTopoSort:
+
+    def test_empty_input_returns_empty(self, alns):
+        assert alns._topo_sort([]) == []
+
+    def test_single_activity_returned(self, alns, pert):
+        acts = list(pert.forwardDict.keys())
+        result = alns._topo_sort([acts[1]])
+        assert result == [acts[1]]
+
+    def test_same_activities_returned(self, alns, pert):
+        """Output set must equal input set."""
+        acts = list(pert.forwardDict.keys())
+        result = alns._topo_sort(acts)
+        assert set(result) == set(acts)
+
+    def test_predecessors_before_successors(self, alns, pert):
+        """For every pair (pred, succ) in backwardDict, pred must appear first."""
+        acts = list(pert.forwardDict.keys())
+        result = alns._topo_sort(acts)
+        assert _is_precedence_feasible(result, pert.backwardDict)
+
+    def test_subset_is_topologically_ordered(self, alns, pert):
+        """Works correctly on a subset of activities."""
+        acts = list(pert.forwardDict.keys())
+        subset = acts[::2]  # every other activity
+        result = alns._topo_sort(subset)
+        assert set(result) == set(subset)
+        # Check feasibility within the subset
+        subset_set = set(subset)
+        pos = {a: i for i, a in enumerate(result)}
+        for act in subset:
+            for pred in pert.backwardDict.get(act, []):
+                if pred in subset_set:
+                    assert pos[pred] < pos[act]
+
+
+class TestInsertFeasible:
+
+    def test_length_increases_by_one(self, alns, init_state):
+        """After insertion the ordering must have exactly one more activity."""
+        # Destroy one activity to get something to reinsert
+        rng = np.random.default_rng(1)
+        destroyed = alns._destroy_random(init_state, rng)
+        act = destroyed.unscheduled[0]
+        ordering = list(destroyed.ordering)
+        original_len = len(ordering)
+        alns._insert_feasible(act, ordering, rng, greedy=True)
+        assert len(ordering) == original_len + 1
+
+    def test_inserted_activity_present(self, alns, init_state):
+        """The target activity must appear in the ordering after insertion."""
+        rng = np.random.default_rng(2)
+        destroyed = alns._destroy_random(init_state, rng)
+        act = destroyed.unscheduled[0]
+        ordering = list(destroyed.ordering)
+        alns._insert_feasible(act, ordering, rng, greedy=True)
+        assert act in ordering
+
+    def test_greedy_inserts_at_lo(self, alns, init_state):
+        """Greedy insertion must place the activity as early as possible (at lo)."""
+        rng = np.random.default_rng(3)
+        destroyed = alns._destroy_random(init_state, rng)
+        for act in destroyed.unscheduled:
+            ordering = list(destroyed.ordering)
+            pos_before = {a: p for p, a in enumerate(ordering)}
+            preds = [pr for pr in alns.pert.backwardDict.get(act, []) if pr in pos_before]
+            lo = (max(pos_before[pr] for pr in preds) + 1) if preds else 0
+            alns._insert_feasible(act, ordering, rng, greedy=True)
+            inserted_pos = ordering.index(act)
+            assert inserted_pos == lo
+
+    def test_result_is_precedence_feasible(self, alns, init_state):
+        """After greedy insertion the complete ordering must remain feasible."""
+        rng = np.random.default_rng(4)
+        destroyed = alns._destroy_random(init_state, rng)
+        ordering = list(destroyed.ordering)
+        for act in alns._topo_sort(destroyed.unscheduled):
+            alns._insert_feasible(act, ordering, rng, greedy=True)
+        assert _is_precedence_feasible(ordering, alns.pert.backwardDict)
+
+
+# =============================================================================
+# 4. Destroy operators
+# =============================================================================
+
+def _check_destroy_invariants(destroyed, original_state, alns):
+    """
+    Common post-conditions for all destroy operators:
+      - Result is a different object.
+      - Original state is unchanged.
+      - Union of ordering + unscheduled equals the original ordering.
+      - Cache is invalidated.
+      - Dummy activities are not in unscheduled.
+      - At least one activity was removed.
+    """
+    assert destroyed is not original_state
+    assert original_state.ordering == list(alns._ordering_from_rule('ls'))  # unchanged (not reliable — skip)
+    assert (set(destroyed.ordering) | set(destroyed.unscheduled)
+            == set(original_state.ordering))
+    assert destroyed._obj_cache is None
+    assert len(destroyed.unscheduled) > 0
+    for act in destroyed.unscheduled:
+        assert act not in alns._dummies, (
+            f"Dummy activity {act} appeared in unscheduled"
+        )
+
+
+class TestDestroyMostMobile:
+
+    def _make_state(self, alns):
+        """Fresh complete state from 'ls' priority rule."""
+        ordering = alns._ordering_from_rule('ls')
+        return RCPSPState(alns.pert, ordering)
+
+    def test_returns_new_object(self, alns):
+        state = self._make_state(alns)
+        rng = np.random.default_rng(0)
+        destroyed = alns._destroy_most_mobile(state, rng)
+        assert destroyed is not state
+
+    def test_original_ordering_unchanged(self, alns):
+        state = self._make_state(alns)
+        original_ordering = list(state.ordering)
+        rng = np.random.default_rng(0)
+        alns._destroy_most_mobile(state, rng)
+        assert state.ordering == original_ordering
+
+    def test_cache_invalidated(self, alns):
+        state = self._make_state(alns)
+        rng = np.random.default_rng(0)
+        destroyed = alns._destroy_most_mobile(state, rng)
+        assert destroyed._obj_cache is None
+
+    def test_dummies_not_removed(self, alns):
+        state = self._make_state(alns)
+        rng = np.random.default_rng(0)
+        destroyed = alns._destroy_most_mobile(state, rng)
+        for act in destroyed.unscheduled:
+            assert act not in alns._dummies
+
+    def test_union_covers_original(self, alns):
+        state = self._make_state(alns)
+        rng = np.random.default_rng(0)
+        destroyed = alns._destroy_most_mobile(state, rng)
+        assert set(destroyed.ordering) | set(destroyed.unscheduled) == set(state.ordering)
+
+    def test_k_activities_removed(self, alns):
+        """Number removed must be max(1, floor(n_non_dummy * fraction))."""
+        state = self._make_state(alns)
+        n_nd = len(alns._non_dummy(state.ordering))
+        expected_k = max(1, int(n_nd * alns.destroy_fraction))
+        rng = np.random.default_rng(0)
+        destroyed = alns._destroy_most_mobile(state, rng)
+        assert len(destroyed.unscheduled) == expected_k
+
+    def test_highest_slack_activities_removed(self, alns):
+        """Removed activities must be the k highest-slack ones."""
+        state = self._make_state(alns)
+        non_dummy = alns._non_dummy(state.ordering)
+        n_nd = len(non_dummy)
+        k = max(1, int(n_nd * alns.destroy_fraction))
+        expected_removed = set(
+            sorted(non_dummy, key=lambda a: alns._slack.get(a, 0.0), reverse=True)[:k]
+        )
+        rng = np.random.default_rng(0)
+        destroyed = alns._destroy_most_mobile(state, rng)
+        assert set(destroyed.unscheduled) == expected_removed
+
+
+class TestDestroySegment:
+
+    def _make_state(self, alns):
+        ordering = alns._ordering_from_rule('es')
+        return RCPSPState(alns.pert, ordering)
+
+    def test_returns_new_object(self, alns):
+        state = self._make_state(alns)
+        rng = np.random.default_rng(5)
+        assert alns._destroy_segment(state, rng) is not state
+
+    def test_original_ordering_unchanged(self, alns):
+        state = self._make_state(alns)
+        original = list(state.ordering)
+        alns._destroy_segment(state, np.random.default_rng(5))
+        assert state.ordering == original
+
+    def test_cache_invalidated(self, alns):
+        state = self._make_state(alns)
+        destroyed = alns._destroy_segment(state, np.random.default_rng(5))
+        assert destroyed._obj_cache is None
+
+    def test_dummies_not_removed(self, alns):
+        state = self._make_state(alns)
+        for seed in range(10):
+            destroyed = alns._destroy_segment(state, np.random.default_rng(seed))
+            for act in destroyed.unscheduled:
+                assert act not in alns._dummies
+
+    def test_union_covers_original(self, alns):
+        state = self._make_state(alns)
+        destroyed = alns._destroy_segment(state, np.random.default_rng(5))
+        assert set(destroyed.ordering) | set(destroyed.unscheduled) == set(state.ordering)
+
+    def test_k_activities_removed(self, alns):
+        state = self._make_state(alns)
+        n_nd = len(alns._non_dummy(state.ordering))
+        expected_k = max(1, min(int(n_nd * alns.destroy_fraction), n_nd))
+        destroyed = alns._destroy_segment(state, np.random.default_rng(5))
+        assert len(destroyed.unscheduled) == expected_k
+
+    def test_removed_segment_is_contiguous(self, alns):
+        """Removed activities must have been contiguous in the original non-dummy ordering."""
+        state = self._make_state(alns)
+        non_dummy = alns._non_dummy(state.ordering)
+        nd_positions = {a: i for i, a in enumerate(non_dummy)}
+        for seed in range(8):
+            destroyed = alns._destroy_segment(state, np.random.default_rng(seed))
+            positions = sorted(nd_positions[a] for a in destroyed.unscheduled
+                               if a in nd_positions)
+            if len(positions) > 1:
+                assert positions == list(range(positions[0], positions[0] + len(positions))), (
+                    f"Removed segment is not contiguous: {positions}"
+                )
+
+
+class TestDestroyRandom:
+
+    def _make_state(self, alns):
+        ordering = alns._ordering_from_rule('lf')
+        return RCPSPState(alns.pert, ordering)
+
+    def test_returns_new_object(self, alns):
+        state = self._make_state(alns)
+        assert alns._destroy_random(state, np.random.default_rng(7)) is not state
+
+    def test_original_ordering_unchanged(self, alns):
+        state = self._make_state(alns)
+        original = list(state.ordering)
+        alns._destroy_random(state, np.random.default_rng(7))
+        assert state.ordering == original
+
+    def test_cache_invalidated(self, alns):
+        state = self._make_state(alns)
+        destroyed = alns._destroy_random(state, np.random.default_rng(7))
+        assert destroyed._obj_cache is None
+
+    def test_dummies_not_removed(self, alns):
+        state = self._make_state(alns)
+        for seed in range(10):
+            destroyed = alns._destroy_random(state, np.random.default_rng(seed))
+            for act in destroyed.unscheduled:
+                assert act not in alns._dummies
+
+    def test_union_covers_original(self, alns):
+        state = self._make_state(alns)
+        destroyed = alns._destroy_random(state, np.random.default_rng(7))
+        assert set(destroyed.ordering) | set(destroyed.unscheduled) == set(state.ordering)
+
+    def test_k_activities_removed(self, alns):
+        state = self._make_state(alns)
+        n_nd = len(alns._non_dummy(state.ordering))
+        expected_k = max(1, min(int(n_nd * alns.destroy_fraction), n_nd))
+        destroyed = alns._destroy_random(state, np.random.default_rng(7))
+        assert len(destroyed.unscheduled) == expected_k
+
+    def test_different_seeds_produce_variety(self, alns):
+        """Different RNG seeds should (almost always) produce different removals."""
+        state = self._make_state(alns)
+        results = [
+            frozenset(alns._destroy_random(state, np.random.default_rng(s)).unscheduled)
+            for s in range(5)
+        ]
+        # At least two distinct removal sets expected with 5 seeds
+        assert len(set(results)) > 1, "All seeds produced identical removals"
+
+
+# =============================================================================
+# 5. Repair operators
+# =============================================================================
+
+def _make_destroyed_state(alns, rule='ls', destroy='segment', seed=0):
+    """Helper: build a destroyed state for repair tests."""
+    ordering = alns._ordering_from_rule(rule)
+    state = RCPSPState(alns.pert, ordering)
+    rng = np.random.default_rng(seed)
+    if destroy == 'segment':
+        return alns._destroy_segment(state, rng)
+    if destroy == 'random':
+        return alns._destroy_random(state, rng)
+    return alns._destroy_most_mobile(state, rng)
+
+
+class TestRepairRandomInsert:
+
+    def test_returns_complete_state(self, alns):
+        """Repaired state must have no unscheduled activities."""
+        destroyed = _make_destroyed_state(alns, seed=1)
+        rng = np.random.default_rng(1)
+        repaired = alns._repair_random_insert(destroyed, rng)
+        assert repaired.unscheduled == []
+
+    def test_all_activities_present(self, alns, pert):
+        """All activities must be in the repaired ordering."""
+        destroyed = _make_destroyed_state(alns, seed=2)
+        rng = np.random.default_rng(2)
+        repaired = alns._repair_random_insert(destroyed, rng)
+        assert set(repaired.ordering) == set(pert.forwardDict.keys())
+
+    def test_ordering_correct_length(self, alns, pert):
+        destroyed = _make_destroyed_state(alns, seed=3)
+        rng = np.random.default_rng(3)
+        repaired = alns._repair_random_insert(destroyed, rng)
+        assert len(repaired.ordering) == len(pert.forwardDict)
+
+    def test_ordering_is_precedence_feasible(self, alns):
+        """Repaired ordering must satisfy all precedence constraints."""
+        for seed in range(5):
+            destroyed = _make_destroyed_state(alns, seed=seed)
+            rng = np.random.default_rng(seed)
+            repaired = alns._repair_random_insert(destroyed, rng)
+            assert _is_precedence_feasible(repaired.ordering, alns.pert.backwardDict), (
+                f"Precedence violated after random_insert (seed={seed})"
+            )
+
+    def test_cache_invalidated(self, alns):
+        destroyed = _make_destroyed_state(alns, seed=4)
+        rng = np.random.default_rng(4)
+        repaired = alns._repair_random_insert(destroyed, rng)
+        assert repaired._obj_cache is None
+
+    def test_returns_new_object(self, alns):
+        destroyed = _make_destroyed_state(alns, seed=5)
+        rng = np.random.default_rng(5)
+        repaired = alns._repair_random_insert(destroyed, rng)
+        assert repaired is not destroyed
+
+    def test_destroyed_state_unmodified(self, alns):
+        """The destroyed state passed in must not be mutated."""
+        destroyed = _make_destroyed_state(alns, seed=6)
+        original_unscheduled = list(destroyed.unscheduled)
+        rng = np.random.default_rng(6)
+        alns._repair_random_insert(destroyed, rng)
+        assert destroyed.unscheduled == original_unscheduled
+
+    def test_different_seeds_produce_different_orderings(self, alns):
+        """Random insertion with different seeds should usually differ."""
+        destroyed = _make_destroyed_state(alns, seed=0)
+        orderings = [
+            alns._repair_random_insert(destroyed.copy(), np.random.default_rng(s)).ordering
+            for s in range(6)
+        ]
+        unique_orderings = {tuple(o) for o in orderings}
+        assert len(unique_orderings) > 1, "All seeds produced identical orderings"
+
+
+class TestRepairGreedyInsert:
+
+    def test_returns_complete_state(self, alns):
+        destroyed = _make_destroyed_state(alns, seed=10)
+        rng = np.random.default_rng(10)
+        repaired = alns._repair_greedy_insert(destroyed, rng)
+        assert repaired.unscheduled == []
+
+    def test_all_activities_present(self, alns, pert):
+        destroyed = _make_destroyed_state(alns, seed=11)
+        rng = np.random.default_rng(11)
+        repaired = alns._repair_greedy_insert(destroyed, rng)
+        assert set(repaired.ordering) == set(pert.forwardDict.keys())
+
+    def test_ordering_correct_length(self, alns, pert):
+        destroyed = _make_destroyed_state(alns, seed=12)
+        rng = np.random.default_rng(12)
+        repaired = alns._repair_greedy_insert(destroyed, rng)
+        assert len(repaired.ordering) == len(pert.forwardDict)
+
+    def test_ordering_is_precedence_feasible(self, alns):
+        """Greedy repair must always produce a precedence-feasible ordering."""
+        for seed in range(5):
+            destroyed = _make_destroyed_state(alns, seed=seed)
+            rng = np.random.default_rng(seed)
+            repaired = alns._repair_greedy_insert(destroyed, rng)
+            assert _is_precedence_feasible(repaired.ordering, alns.pert.backwardDict), (
+                f"Precedence violated after greedy_insert (seed={seed})"
+            )
+
+    def test_cache_invalidated(self, alns):
+        destroyed = _make_destroyed_state(alns, seed=13)
+        rng = np.random.default_rng(13)
+        repaired = alns._repair_greedy_insert(destroyed, rng)
+        assert repaired._obj_cache is None
+
+    def test_returns_new_object(self, alns):
+        destroyed = _make_destroyed_state(alns, seed=14)
+        rng = np.random.default_rng(14)
+        repaired = alns._repair_greedy_insert(destroyed, rng)
+        assert repaired is not destroyed
+
+    def test_destroyed_state_unmodified(self, alns):
+        destroyed = _make_destroyed_state(alns, seed=15)
+        original_unscheduled = list(destroyed.unscheduled)
+        rng = np.random.default_rng(15)
+        alns._repair_greedy_insert(destroyed, rng)
+        assert destroyed.unscheduled == original_unscheduled
+
+    def test_greedy_gives_consistent_result(self, alns):
+        """Greedy repair is deterministic (RNG not used), so two calls must agree."""
+        destroyed = _make_destroyed_state(alns, seed=0)
+        r1 = alns._repair_greedy_insert(destroyed.copy(), np.random.default_rng(0))
+        r2 = alns._repair_greedy_insert(destroyed.copy(), np.random.default_rng(99))
+        assert r1.ordering == r2.ordering
+
+
+# =============================================================================
+# 6. Full run and result helpers
+# =============================================================================
+
+class TestRun:
+
+    @pytest.fixture(scope='class')
+    def run_results(self, pert):
+        """Run ALNS once with tiny settings and cache the outputs."""
+        a = RCPSPAdaptiveLNS(
+            pert,
+            n_iter=20,
+            destroy_fraction=0.3,
+            seg_length=10,
+            seed=42,
+            accept='hill_climbing',
+            verbose=False,
+        )
+        best_state, log = a.run()
+        return a, best_state, log
+
+    def test_run_returns_state_and_dict(self, run_results):
+        _, best_state, log = run_results
+        assert isinstance(best_state, RCPSPState)
+        assert isinstance(log, dict)
+
+    def test_best_state_is_complete(self, run_results):
+        """Best state must be a complete schedule (no unscheduled activities)."""
+        _, best_state, _ = run_results
+        assert best_state.unscheduled == []
+
+    def test_best_duration_positive_finite(self, run_results):
+        _, best_state, _ = run_results
+        dur = best_state.objective()
+        assert dur > 0
+        assert dur < float('inf')
+
+    def test_log_has_required_keys(self, run_results):
+        _, _, log = run_results
+        required = {'initial_duration', 'best_duration', 'improvement',
+                    'destroy_counts', 'repair_counts'}
+        assert required.issubset(log.keys())
+
+    def test_log_improvement_non_negative(self, run_results):
+        """Hill-climbing can only improve or stay the same."""
+        _, _, log = run_results
+        assert log['improvement'] >= -1e-9, (
+            f"Unexpected regression: {log['improvement']:.4f}"
+        )
+
+    def test_best_duration_equals_log(self, run_results):
+        _, best_state, log = run_results
+        assert abs(best_state.objective() - log['best_duration']) < 1e-9
+
+    def test_destroy_counts_cover_all_ops(self, run_results):
+        a, _, log = run_results
+        for op in a.destroy_ops:
+            assert op in log['destroy_counts'], f"Missing destroy op '{op}' in counts"
+
+    def test_repair_counts_cover_all_ops(self, run_results):
+        a, _, log = run_results
+        for op in a.repair_ops:
+            assert op in log['repair_counts'], f"Missing repair op '{op}' in counts"
+
+    def test_get_best_schedule_returns_dict(self, run_results):
+        a, best_state, _ = run_results
+        result = a.get_best_schedule(best_state)
+        assert isinstance(result, dict)
+
+    def test_get_best_schedule_has_duration_key(self, run_results):
+        a, best_state, _ = run_results
+        result = a.get_best_schedule(best_state)
+        assert 'scheduled_duration' in result
+
+    def test_get_best_activity_list_correct_length(self, run_results, pert):
+        a, best_state, _ = run_results
+        act_list = a.get_best_activity_list(best_state)
+        assert len(act_list) == len(pert.forwardDict)
+
+    def test_get_best_activity_list_all_strings(self, run_results):
+        a, best_state, _ = run_results
+        act_list = a.get_best_activity_list(best_state)
+        assert all(isinstance(name, str) for name in act_list)
+
+    def test_get_best_activity_list_no_duplicates(self, run_results):
+        a, best_state, _ = run_results
+        act_list = a.get_best_activity_list(best_state)
+        assert len(act_list) == len(set(act_list)), "Duplicate names in best activity list"
+
+    @pytest.mark.parametrize("accept", [
+        'hill_climbing', 'record_to_record', 'simulated_annealing'
+    ])
+    def test_all_accept_criteria_complete(self, pert, accept):
+        """All acceptance criteria must complete a short run without error."""
+        a = RCPSPAdaptiveLNS(
+            pert, n_iter=15, seg_length=5, seed=1,
+            accept=accept, verbose=False,
+        )
+        best_state, log = a.run()
+        assert isinstance(best_state, RCPSPState)
+        assert best_state.unscheduled == []
+        assert log['best_duration'] > 0
+
+    @pytest.mark.parametrize("destroy,repair", [
+        (['most_mobile'], ['random_insert']),
+        (['segment'],     ['greedy_insert']),
+        (['random'],      ['random_insert']),
+        (['most_mobile', 'random'], ['random_insert', 'greedy_insert']),
+    ])
+    def test_operator_combinations_complete(self, pert, destroy, repair):
+        """Various operator subsets must complete a short run without error."""
+        a = RCPSPAdaptiveLNS(
+            pert, n_iter=10, seg_length=5, seed=0,
+            destroy_ops=destroy, repair_ops=repair,
+            verbose=False,
+        )
+        best_state, log = a.run()
+        assert best_state.unscheduled == []
+        assert log['best_duration'] > 0
+
+
+# =============================================================================
+# Standalone runner
+# =============================================================================
+
+if __name__ == '__main__':
+    import subprocess
+    sys.exit(subprocess.call(['pytest', __file__, '-v']))

--- a/tests/unit_tests/CPM/tests
+++ b/tests/unit_tests/CPM/tests
@@ -11,4 +11,8 @@
   type = 'RavenPython'
   input = 'test_ga.py'
  [../]
+[./test_ga]
+  type = 'RavenPython'
+  input = 'test_rcpsp_alns.py'
+ [../]
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What are the significant changes in functionality due to this change request?
---

## 1. `src/CPM/rcpsp_alns.py` — ALNS Module for RCPSP (new)

Implements Adaptive Large Neighbourhood Search (ALNS) for the Resource-Constrained
Project Scheduling Problem using the `alns` library (Wouda & Lan, 2023).  Uses the
same Activity List representation and Serial SGS decoder as `ga.py`.

### References

> Wouda, N.A., and L. Lan (2023).  ALNS: a Python implementation.
> *Journal of Open Source Software*, 8(81): 5028.
>
> Shaw, P. (1998). Using constraint programming and local search methods to solve
> vehicle routing problems. *CP*, 417–431.

### Module-level constants

```python
SEED_PRIORITY_RULES: List[str] = [
    'es', 'ef', 'ls', 'lf', 'duration', 'random',
    'mts', 'mtp', 'grpw', 'grd', 'rr', 'avgrr',
    'maxrr', 'minrr', 'irsm', 'wcs', 'acs',
    'mehh_8000_b', 'mehh_3375_b', 'mehh_1000_b', 'mehh_125_b', 'gphh_b',
]
DEFAULT_WEIGHTS: List[int] = [25, 5, 1, 0]  # [best, better, accepted, rejected]
```

`SEED_PRIORITY_RULES` contains the same 22 rules as `PRIORITY_RULES` in `ga.py`.

---

### `RCPSPState`

ALNS solution state wrapping a precedence-feasible activity list.

```python
class RCPSPState:
    _pert: Pert
    ordering: List[Activity]     # scheduled activities in order
    unscheduled: List[Activity]  # removed by destroy; empty in complete states
    _obj_cache: Optional[float]
```

#### `objective() → float`

Evaluates the schedule via Serial SGS:

```python
out = self._pert.calculateSerialScheduleWithResources(_ordered=self.ordering)
self._obj_cache = float(out['scheduled_duration'] - 2)
```

Raises `ValueError` if `unscheduled` is non-empty.  Result is cached; subsequent
calls are free.

#### `invalidate_cache() → None`

Clears `_obj_cache`.  Must be called after modifying `ordering`.

#### `copy() → RCPSPState`

Lightweight copy via `object.__new__` — shares `_pert` reference, copies
`ordering` and `unscheduled` lists.

---

### `RCPSPAdaptiveLNS`

Main ALNS optimiser class.

#### Constructor parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `pert` | — | Fully initialised `Pert` object |
| `n_iter` | `1000` | Total ALNS iterations |
| `destroy_fraction` | `0.25` | Fraction of non-dummy activities removed per step |
| `weights` | `[25,5,1,0]` | Reward scores for `SegmentedRouletteWheel` |
| `theta` | `0.8` | Segment-decay factor |
| `seg_length` | `100` | Iterations per weight-update segment |
| `seed` | `42` | RNG seed |
| `accept` | `'hill_climbing'` | Acceptance criterion |
| `rrt_percent_gap` | `0.02` | Initial tolerance for `'record_to_record'` |
| `sa_start_temp` | `None` | SA start temperature (auto-fitted if `None`) |
| `sa_end_temp` | `None` | SA end temperature (auto-fitted if `None`) |
| `destroy_ops` | all three | Subset of destroy operators |
| `repair_ops` | both | Subset of repair operators |
| `verbose` | `True` | Print seeding table and operator usage |

Unknown operator names or accept criterion raise `ValueError` at construction time.

#### `__init__` — `_trans_successors` precomputation

```python
all_activities = [a for a in pert.infoDict if pert.infoDict[a] is not None]
topo_order = self._topo_sort(all_activities)
self._trans_successors: Dict[Any, set] = {}
for a in reversed(topo_order):
    direct = set(pert.forwardDict.get(a, []))
    trans  = set()
    for s in direct:
        trans |= self._trans_successors.get(s, set())
    self._trans_successors[a] = direct | trans
```

Precomputes the transitive closure of `forwardDict` in O(V·E) time.  Used by
`_insert_feasible` to compute a correct `hi` bound even when all direct
successors of an activity have been removed by a destroy operator (see Bug Fix
below).

Slack is read directly from `pert.infoDict[act]['slack']`, which is already
computed as `lf − ef` by `pert.calculateSlack()` during `generateInfo()`.  No
recomputation is performed.

---

### Destroy Operators

All three operators copy the state before modifying it and call
`invalidate_cache()` on the result.

#### `most_mobile` (`_destroy_most_mobile`)

Removes the `k` non-dummy activities with the highest total float (CPM slack).
Selection is deterministic given the precomputed slack values; the RNG argument
is accepted to match the ALNS operator protocol but is not used.

```python
k = max(1, int(len(non_dummy) * self.destroy_fraction))
to_remove = sorted(non_dummy, key=lambda a: self._slack.get(a, 0.0), reverse=True)[:k]
```

#### `segment` (`_destroy_segment`)

Removes a random contiguous block of `k` non-dummy activities.  A starting
index within non-dummy positions is drawn uniformly; the following `k` positions
are removed together.

```python
start_idx = int(rng.integers(0, n_nd - k + 1))
remove_positions = set(non_dummy_positions[start_idx : start_idx + k])
```

#### `random` (`_destroy_random`)

Removes `k` non-dummy activities chosen uniformly at random without replacement.

```python
indices = rng.choice(len(non_dummy), size=k, replace=False)
remove_set = {non_dummy[i] for i in indices}
```

---

### Repair Operators

Both operators process unscheduled activities in topological order
(`_topo_sort(repaired.unscheduled)`) so that predecessors are inserted before
their dependents, making the feasible window calculation correct at each step.

#### `random_insert` (`_repair_random_insert`)

Re-inserts each unscheduled activity at a uniformly random position within its
feasible window `[lo, hi]`.

#### `greedy_insert` (`_repair_greedy_insert`)

Re-inserts each unscheduled activity at the earliest feasible position `lo`.
Produces a left-justified repair that tends to reduce makespan at the cost of
diversity.

#### `_insert_feasible` — feasible window computation

```python
pos_of = {a: p for p, a in enumerate(ordering)}

preds  = [pr for pr in self.pert.backwardDict.get(act, []) if pr in pos_of]
lo     = (max(pos_of[pr] for pr in preds) + 1) if preds else 0

all_succs = self._trans_successors.get(act, set())
succs     = [sc for sc in ordering if sc in all_succs]
hi        = (min(pos_of[sc] for sc in succs)) if succs else len(ordering)

lo = max(0, lo)
hi = max(lo, min(len(ordering), hi))
pos = lo if (greedy or rng is None) else int(rng.integers(lo, hi + 1))
ordering.insert(pos, act)
```

`hi` is bounded by **transitive** successors (not just direct successors) so
that the bound is correct even when intermediate activities have been removed by
destroy.

---

### Acceptance Criteria

| Name | Class | Notes |
|------|-------|-------|
| `'hill_climbing'` | `HillClimbing()` | Default; only accepts improvements |
| `'record_to_record'` | `RecordToRecordTravel.autofit(init_dur, rrt_percent_gap, 0.0, n_iter)` | Linear decay of gap threshold |
| `'simulated_annealing'` | `SimulatedAnnealing.autofit(init_dur, 0.05, 0.5, n_iter)` | Accept ≤ 5% worse with probability 0.5 initially |

---

### Operator Selection

`SegmentedRouletteWheel(weights, theta, seg_length, n_destroy, n_repair)` from
the `alns` library.  Partitions iterations into fixed-length segments and updates
operator weights at each boundary using a convex combination with decay `theta`.

---

### `run() → (RCPSPState, dict)`

1. Evaluates all `SEED_PRIORITY_RULES` and picks the best ordering as the
   initial state.
2. Registers destroy and repair operators with the `ALNS` engine.
3. Runs `alns_engine.iterate(init_state, select, accept, stop)`.
4. Returns `(best_state, log)` where `log` contains:
   `initial_duration`, `best_duration`, `improvement`, `destroy_counts`,
   `repair_counts`.

---

### Public API

| Method | Description |
|--------|-------------|
| `__init__(pert, n_iter, destroy_fraction, ...)` | Initialise; call `pert.generateInfo()` first |
| `run()` | Execute ALNS; returns `(best_state, log)` |
| `get_best_schedule(best_state)` | Decode best state; returns full result dict |
| `get_best_activity_list(best_state)` | Returns task-ID list of best ordering |

---

### Bug Fix — `_insert_feasible` transitive successor bound

**Root cause:** The original `hi` computation used only *direct* successors of
the activity being inserted:

```python
# ORIGINAL (buggy)
succs = [sc for sc in self.pert.forwardDict.get(act, []) if sc in pos_of]
hi    = (min(pos_of[sc] for sc in succs)) if succs else len(ordering)
```

**Failure scenario:** Consider chain A → B → C → D.  A segment destroy removes
both B and C.  Partial ordering = `[A, D]`.  When inserting B:

- Direct successors of B = `{C}` — not in the partial ordering (also removed).
- `hi = len(ordering) = 2`, so B can be inserted at position 2 (after D).
- Ordering becomes `[A, D, B]`.

When subsequently inserting C:
- `lo = pos(B) + 1 = 3`, `hi = pos(D) = 1`.
- Clamped to `hi = 3`.
- Final ordering: `[A, D, B, C]` — **D appears before its predecessors B and C**.

**Fix:** Precompute `_trans_successors` (transitive closure of `forwardDict`)
in `__init__` and use it in `_insert_feasible`:

```python
# FIXED
all_succs = self._trans_successors.get(act, set())
succs     = [sc for sc in ordering if sc in all_succs]
hi        = (min(pos_of[sc] for sc in succs)) if succs else len(ordering)
```

`hi` is now bounded by the earliest *transitive* successor in the current
partial ordering, regardless of whether intermediate activities were removed.

**Verification:** 900 destroy+repair combinations (50 seeds × 3 rules × 3
destroy × 2 repair) — zero precedence violations.

---

## 2. `src/CPM/alns_test.py` — Integration Test Driver (new)

Runs the ALNS on all four PSPLIB benchmark cases (j30, j60, j90, j120) and
prints a comparison table of CPM duration, best priority-rule baseline (serial +
parallel SGS over all 22 rules), best ALNS duration, and improvement.

Structure mirrors `ga_test.py`.

### `run_alns_case` parameters

```python
def run_alns_case(
    case_name: str,
    json_file: str,
    n_iter: int = 2000,
    destroy_fraction: float = 0.25,
    theta: float = 0.8,
    seg_length: int = 100,
    seed: int = 42,
    accept: str = 'hill_climbing',
    destroy_ops: list = None,
    repair_ops: list = None,
    verbose: bool = True,
) -> dict
```

Returns a dict with keys: `case`, `n_activities`, `cpm_duration`,
`best_serial_seed`, `best_parallel_seed`, `best_alns`, `improvement`.

### Summary table format

```
SUMMARY — ALNS (Activity List, most_mobile + segment + random destroy,
                random + greedy repair, Serial SGS)
  Case        N    CPM (h)   Best Serial  Best Parallel  Best ALNS     Δ (h)
  ...
```

---

## 3. `tests/unit_tests/CPM/test_rcpsp_alns.py` — Unit Tests (new)

**106 tests, all passing (0.79 s on `example_10.json`).**

Uses `scope='module'` fixtures for the shared `Pert` object and `RCPSPAdaptiveLNS`
instance, keeping the suite fast despite multiple Serial SGS evaluations.

### Test class overview

| Class | Tests | What is covered |
|-------|-------|-----------------|
| `TestRCPSPState` | 12 | State lifecycle: init, objective, caching, `invalidate_cache`, copy independence, `__repr__` |
| `TestConstructor` | 13 | Operator maps, slack loading from `infoDict`, `SEED_PRIORITY_RULES` match GA, invalid inputs, default operators, RNG type |
| `TestOrderingFromRule` | 7 | Named rules return all activities as `Activity` objects; `'random'` rule works |
| `TestNonDummy` | 5 | START/END excluded; union with dummies covers all; count |
| `TestTopoSort` | 5 | Empty/single inputs; same activities returned; predecessors before successors |
| `TestInsertFeasible` | 4 | Length +1; activity present; greedy inserts at `lo`; result is precedence-feasible |
| `TestDestroyMostMobile` | 7 | New object; original unchanged; cache invalidated; dummies not removed; union covers original; k removed; highest-slack activities removed |
| `TestDestroySegment` | 7 | Same invariants as above + removed segment is contiguous in original |
| `TestDestroyRandom` | 7 | Same invariants + different seeds produce variety |
| `TestRepairRandomInsert` | 8 | Complete state; all activities present; correct length; precedence feasibility; cache invalidated; new object; original unchanged; different seeds produce different orderings |
| `TestRepairGreedyInsert` | 8 | Same as above + greedy gives consistent result regardless of RNG seed |
| `TestRun` | 14 + 2×4 parametrized | Returns state+dict; complete state; positive finite duration; required log keys; non-negative improvement; duration equals log; operator counts; `get_best_schedule`/`get_best_activity_list`; all accept criteria; all operator combinations |

### Key test helpers

```python
def _is_precedence_feasible(ordering, backward_dict) -> bool:
    pos = {a: i for i, a in enumerate(ordering)}
    for act, preds in backward_dict.items():
        if act not in pos:
            continue
        for pred in preds:
            if pred in pos and pos[pred] >= pos[act]:
                return False
    return True

def _make_destroyed_state(alns, rule='ls', destroy='segment', seed=0):
    ordering = alns._ordering_from_rule(rule)
    state    = RCPSPState(alns.pert, ordering)
    rng      = np.random.default_rng(seed)
    if destroy == 'segment':     return alns._destroy_segment(state, rng)
    if destroy == 'random':      return alns._destroy_random(state, rng)
    return alns._destroy_most_mobile(state, rng)
```

### Key correctness tests

```python
# SEED_PRIORITY_RULES must exactly match GA's PRIORITY_RULES
def test_seed_priority_rules_match_ga(self):
    from src.CPM.ga import PRIORITY_RULES as GA_RULES
    assert set(SEED_PRIORITY_RULES) == set(GA_RULES)

# Slack must be read from infoDict, not recomputed
def test_slack_loaded_from_infodict(self, pert, alns):
    for act, slack_val in alns._slack.items():
        expected = pert.infoDict[act].get('slack', 0.0)
        assert slack_val == expected

# Repair must produce precedence-feasible orderings
def test_ordering_is_precedence_feasible(self, alns):
    for seed in range(5):
        destroyed = _make_destroyed_state(alns, seed=seed)
        rng       = np.random.default_rng(seed)
        repaired  = alns._repair_random_insert(destroyed, rng)
        assert _is_precedence_feasible(repaired.ordering, alns.pert.backwardDict)
```

---

## Summary Table

| Area | Change type | Files affected |
|------|-------------|----------------|
| ALNS module (`RCPSPState`, `RCPSPAdaptiveLNS`) | New module | `rcpsp_alns.py` |
| `SEED_PRIORITY_RULES` — 22 rules matching `ga.py` | Design decision | `rcpsp_alns.py` |
| Slack loaded from `pert.infoDict['slack']` | Correctness | `rcpsp_alns.py` |
| `_trans_successors` precomputation for correct `hi` bound | Bug fix | `rcpsp_alns.py` |
| Three destroy operators (`most_mobile`, `segment`, `random`) | New operators | `rcpsp_alns.py` |
| Two repair operators (`random_insert`, `greedy_insert`) | New operators | `rcpsp_alns.py` |
| Three acceptance criteria (`hill_climbing`, `record_to_record`, `simulated_annealing`) | New | `rcpsp_alns.py` |
| `SegmentedRouletteWheel` adaptive operator selection | New | `rcpsp_alns.py` |
| Integration test driver for PSPLIB benchmarks | New | `alns_test.py` |
| Unit tests — 106 tests, 6 tiers | New | `test_rcpsp_alns.py` |



