### PR TITLE
add consensus_reorder mutation operator

### DIFF
--- a/src/CPM/ga.py
+++ b/src/CPM/ga.py
@@ -133,6 +133,9 @@ class RCPSPGeneticAlgorithm:
         Probability of applying crossover to a selected pair of parents.
     seed : int
         RNG seed for reproducibility.
+    n_random : int
+        Number of additional random precedence-feasible reference orderings
+        to include in the consensus library.
     hof_size : int
         Number of elite individuals kept in the Hall of Fame across all
         generations.
@@ -150,6 +153,7 @@ class RCPSPGeneticAlgorithm:
         * ``'swap'``              — random swap with topological repair
         * ``'adjacent_swap'``     — adjacent-swap with feasibility check (default)
         * ``'insertion_window'``  — precedence-window insertion
+        * ``'consensus_reorder'`` — local reorder guided by consensus references
     """
 
     # DEAP creator type names (module-level singletons; guarded against
@@ -168,6 +172,7 @@ class RCPSPGeneticAlgorithm:
         'swap':             '_mutate_swap',
         'adjacent_swap':    '_mutate_adjacent_swap',
         'insertion_window': '_mutate_insertion_window',
+        'consensus_reorder': '_mutate_consensus_reorder',
     }
 
     def __init__(
@@ -178,6 +183,7 @@ class RCPSPGeneticAlgorithm:
         cxpb: float = 0.7,
         mutpb: float = 0.1,
         seed: int = 42,
+        n_random: int = 8,
         hof_size: int = 5,
         verbose: bool = True,
         crossover: str = 'two_point',
@@ -199,6 +205,7 @@ class RCPSPGeneticAlgorithm:
         self.n_gen = n_gen
         self.cxpb = cxpb
         self.mutpb = mutpb
+        self.n_random = n_random
         self.hof_size = hof_size
         self.verbose = verbose
         self.crossover = crossover
@@ -213,8 +220,11 @@ class RCPSPGeneticAlgorithm:
         self._act_to_idx: Dict[Any, int] = {
             a: i for i, a in enumerate(self._activities)
         }
+        self._consensus_library: List[List[int]] = []
+        self._consensus_position_maps: List[Dict[int, int]] = []
 
         self._setup_deap()
+        self._build_consensus_library(self.n_random)
 
     # ---------------------------------------------------------------------- #
     # DEAP registration                                                        #
@@ -283,6 +293,52 @@ class RCPSPGeneticAlgorithm:
     def _chromosome_to_activities(self, chromosome: List[int]) -> List[Any]:
         """Convert an index-list chromosome to an ordered list of Activity objects."""
         return [self._activities[i] for i in chromosome]
+
+    def _repair_chromosome(self, chromosome: List[int]) -> List[int]:
+        """
+        Restore precedence feasibility while preserving the perturbed order
+        as closely as possible.
+        """
+        acts = self._chromosome_to_activities(chromosome)
+        ranked = [(a, pos) for pos, a in enumerate(acts)]
+        repaired = self.pert.reorder_by_dependencies(ranked, self.pert.forwardDict)
+        return [self._act_to_idx[a] for a, _ in repaired]
+
+    def _build_consensus_library(self, n_random: int) -> None:
+        """
+        Build a small library of precedence-feasible reference orderings used
+        by consensus-guided mutation.
+        """
+        references: List[List[int]] = []
+        seen: set[Tuple[int, ...]] = set()
+
+        for rule in PRIORITY_RULES:
+            try:
+                chromosome = self._rule_to_chromosome(rule)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "Skipping rule '%s' in consensus library construction: %s",
+                    rule,
+                    exc,
+                )
+                continue
+            key = tuple(chromosome)
+            if key not in seen:
+                references.append(chromosome)
+                seen.add(key)
+
+        for _ in range(n_random):
+            chromosome = self._rule_to_chromosome('random')
+            key = tuple(chromosome)
+            if key not in seen:
+                references.append(chromosome)
+                seen.add(key)
+
+        self._consensus_library = references
+        self._consensus_position_maps = [
+            {gene: pos for pos, gene in enumerate(chromosome)}
+            for chromosome in references
+        ]
 
     # ---------------------------------------------------------------------- #
     # Initial population                                                       #
@@ -656,13 +712,7 @@ class RCPSPGeneticAlgorithm:
         # Build (Activity, rank) pairs from the perturbed ordering.
         # rank = position index so reorder_by_dependencies preserves the swap
         # wherever precedence allows it.
-        acts = self._chromosome_to_activities(individual)
-        ranked = [(a, pos) for pos, a in enumerate(acts)]
-
-        # Repair to topological feasibility.
-        repaired = self.pert.reorder_by_dependencies(ranked, self.pert.forwardDict)
-
-        individual[:] = [self._act_to_idx[a] for a, _ in repaired]
+        individual[:] = self._repair_chromosome(individual)
         return (individual,)
 
     def _mutate_adjacent_swap(
@@ -797,6 +847,64 @@ class RCPSPGeneticAlgorithm:
 
         return (individual,)
 
+    def _mutate_consensus_reorder(self, individual: List[int]) -> Tuple[List[int]]:
+        """
+        Consensus-guided block reorder mutation.
+
+        The operator perturbs a local window of the chromosome using a
+        consensus ranking induced by several reference orderings. This follows
+        the spirit of consensus recombination: preserve agreements that recur
+        across multiple good precedence-feasible schedules, but apply them as
+        a unary mutation to a single individual.
+
+        Algorithm
+        ---------
+        1. Select a random interior window [lo..hi] of non-dummy genes.
+        2. Sample a small number of precedence-feasible reference orderings
+           from the consensus library.
+        3. For each gene in the window, compute its average position across
+           the sampled references.
+        4. Reorder only the genes inside the window by that consensus score,
+           breaking ties by the current order.
+        5. Apply topological repair to restore precedence feasibility if the
+           local reorder conflicts with dependency constraints.
+
+        Returns
+        -------
+        tuple
+            ``(individual,)`` — single-element tuple per DEAP convention.
+        """
+        n = len(individual)
+        if n < 6 or not self._consensus_position_maps:
+            return (individual,)
+
+        interior_positions = list(range(1, n - 1))
+        if len(interior_positions) < 3:
+            return (individual,)
+
+        max_window = min(8, len(interior_positions))
+        window_len = random.randint(3, max_window)
+        lo = random.randint(1, n - 1 - window_len)
+        hi = lo + window_len
+
+        current_window = individual[lo:hi]
+        current_rank = {gene: offset for offset, gene in enumerate(current_window)}
+
+        sample_size = min(5, len(self._consensus_position_maps))
+        sampled_maps = random.sample(self._consensus_position_maps, sample_size)
+
+        def consensus_score(gene: int) -> Tuple[float, int]:
+            avg_pos = sum(pos_map[gene] for pos_map in sampled_maps) / sample_size
+            return avg_pos, current_rank[gene]
+
+        reordered_window = sorted(current_window, key=consensus_score)
+        if reordered_window == current_window:
+            return (individual,)
+
+        individual[lo:hi] = reordered_window
+        individual[:] = self._repair_chromosome(individual)
+        return (individual,)
+
     # ---------------------------------------------------------------------- #
     # Main optimisation loop                                                   #
     # ---------------------------------------------------------------------- #
@@ -812,7 +920,7 @@ class RCPSPGeneticAlgorithm:
         3. For each of ``n_gen`` generations:
            a. Tournament selection.
            b. Pairwise crossover with probability ``cxpb``.
-           c. Swap mutation with probability ``mutpb``.
+           c. Apply the configured mutation operator with probability ``mutpb``.
            d. Re-evaluate invalidated offspring.
            d. Generational replacement.
            e. Update Hall of Fame and statistics logbook.

--- a/src/CPM/ga_test.py
+++ b/src/CPM/ga_test.py
@@ -26,6 +26,7 @@ Or from the repo root:
 
 import sys
 import logging
+import json
 from pathlib import Path
 
 
@@ -39,6 +40,7 @@ from src.CPM.ga import RCPSPGeneticAlgorithm, PRIORITY_RULES  # noqa: E402
 logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 SCHEMA = Path(__file__).parent / "outage_schema.json"
+BEST_RESULTS_PATH = Path(__file__).parent / "benchmarks" / "best_results.json"
 
 CASES = [
     ("j30",  "j301_1.json"),
@@ -46,6 +48,18 @@ CASES = [
     ("j90",  "j901_1.json"),
     ("j120", "j1201_1.json"),
 ]
+
+
+def load_best_known_results() -> dict[str, float]:
+    """Load PSPLIB best-known results keyed by `<instance>.sm`."""
+    with BEST_RESULTS_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_best_known_result(best_results: dict[str, float], json_file: str) -> float | None:
+    """Resolve the benchmark JSON filename to the corresponding PSPLIB result key."""
+    instance_key = f"{Path(json_file).stem}.sm"
+    return best_results.get(instance_key)
 
 
 def run_ga_case(
@@ -207,6 +221,7 @@ def run_ga_case(
 
 def main() -> None:
     """Run the GA on all benchmark cases and print a summary table."""
+    best_results = load_best_known_results()
     results = []
     for case_name, json_file in CASES:
         result = run_ga_case(
@@ -219,6 +234,11 @@ def main() -> None:
             seed=42,
             verbose=True,
         )
+        best_known = get_best_known_result(best_results, json_file)
+        result['best_known'] = best_known
+        result['ga_vs_best_known'] = (
+            result['best_ga'] - best_known if best_known is not None else float('nan')
+        )
         results.append(result)
 
     # ── Summary table ─────────────────────────────────────────────────────────
@@ -227,14 +247,16 @@ def main() -> None:
     print("=" * 80)
     print(
         f"  {'Case':<8} {'N':>6} {'CPM (h)':>10} "
-        f"{'Best Serial':>13} {'Best Parallel':>14} {'Best GA':>10} {'Δ (h)':>8}"
+        f"{'Best Serial':>13} {'Best Parallel':>14} {'Best GA':>10} "
+        f"{'Best Known':>12} {'GA-BK':>8} {'Δ (h)':>8}"
     )
-    print("  " + "-" * 72)
+    print("  " + "-" * 94)
     for r in results:
         print(
             f"  {r['case']:<8} {r['n_activities']:>6} {r['cpm_duration']:>10.2f} "
             f"{r['best_serial_seed']:>13.2f} {r['best_parallel_seed']:>14.2f} "
-            f"{r['best_ga']:>10.2f} {r['improvement']:>8.2f}"
+            f"{r['best_ga']:>10.2f} {r['best_known']:>12.2f} "
+            f"{r['ga_vs_best_known']:>8.2f} {r['improvement']:>8.2f}"
         )
     print()
 

--- a/src/CPM/ga_test_hard.py
+++ b/src/CPM/ga_test_hard.py
@@ -1,0 +1,266 @@
+"""
+ga_test_hard.py — Hard-instance integration test for the RCPSP Genetic Algorithm (ga.py)
+
+Runs the GA on a selected set of difficult PSPLIB j120 benchmark instances and prints
+a comparison table of:
+  - Best duration from all named priority rules (serial + parallel SGS)
+  - Best GA duration (activity list chromosome + serial SGS decoder)
+  - Improvement over the best seeded solution
+
+The GA uses the Activity List representation with configurable crossover
+and mutation operators.  Decoding is performed by the Serial SGS.
+Default operators: two-point crossover, adjacent-swap mutation.
+
+Reference
+---------
+Kolisch, R. and Hartmann, S. (1999). Heuristic Algorithms for Solving the
+Resource-Constrained Project Scheduling Problem. In J. Weglarz (ed.),
+Project Scheduling: Recent Models, Algorithms and Applications, 147-178.
+
+Usage (from the src/CPM directory):
+    python ga_test_hard.py
+
+Or from the repo root:
+    python -m src.CPM.ga_test_hard
+"""
+
+import sys
+import logging
+import json
+from pathlib import Path
+
+
+
+# Ensure repo root is on the path before project imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src import Pert  # noqa: E402
+from src.CPM.ga import RCPSPGeneticAlgorithm, PRIORITY_RULES  # noqa: E402
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+SCHEMA = Path(__file__).parent / "outage_schema.json"
+BEST_RESULTS_PATH = Path(__file__).parent / "benchmarks" / "best_results.json"
+
+CASES = [
+    ("j12051_6",  "benchmarks/PSPLIB_Json/j120/j12051_6.json"),
+    ("j12031_10", "benchmarks/PSPLIB_Json/j120/j12031_10.json"),
+    # ("j12036_6",  "benchmarks/PSPLIB_Json/j120/j12036_6.json"),
+    # ("j12056_7",  "benchmarks/PSPLIB_Json/j120/j12056_7.json"),
+    # ("j12051_5",  "benchmarks/PSPLIB_Json/j120/j12051_5.json"),
+    # ("j12056_1",  "benchmarks/PSPLIB_Json/j120/j12056_1.json"),
+    # ("j12026_10", "benchmarks/PSPLIB_Json/j120/j12026_10.json"),
+    # ("j12051_7",  "benchmarks/PSPLIB_Json/j120/j12051_7.json"),
+    # ("j12056_5",  "benchmarks/PSPLIB_Json/j120/j12056_5.json"),
+    # ("j12056_9",  "benchmarks/PSPLIB_Json/j120/j12056_9.json"),
+]
+
+
+def load_best_known_results() -> dict[str, float]:
+    """Load PSPLIB best-known results keyed by `<instance>.sm`."""
+    with BEST_RESULTS_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_best_known_result(best_results: dict[str, float], json_file: str) -> float | None:
+    """Resolve the benchmark JSON filename to the corresponding PSPLIB result key."""
+    instance_key = f"{Path(json_file).stem}.sm"
+    return best_results.get(instance_key)
+
+
+def run_ga_case(
+    case_name: str,
+    json_file: str,
+    pop_size: int = 30,
+    n_gen: int = 500,
+    cxpb: float = 0.8,
+    mutpb: float = 0.1,
+    n_random=8,
+    seed: int = 42,
+    verbose: bool = True,
+    crossover: str = 'two_point',
+    mutation: str = 'adjacent_swap',
+) -> dict:
+    """
+    Run the GA on a single PSPLIB benchmark case.
+
+    Parameters
+    ----------
+    case_name : str
+        Human-readable label (e.g. 'j12051_6').
+    json_file : str
+        Path to the input JSON relative to this file's directory.
+    pop_size : int
+        GA population size.
+    n_gen : int
+        Number of GA generations.
+    cxpb : float
+        Crossover probability.
+    mutpb : float
+        Per-individual mutation probability.
+    seed : int
+        RNG seed.
+    verbose : bool
+        Print per-generation stats and seeding table.
+    crossover : str
+        Crossover operator name passed to ``RCPSPGeneticAlgorithm``.
+        One of ``'one_point'``, ``'two_point'``, ``'uniform_order'``.
+    mutation : str
+        Mutation operator name passed to ``RCPSPGeneticAlgorithm``.
+        One of ``'swap'``, ``'adjacent_swap'``, ``'insertion_window'``.
+
+    Returns
+    -------
+    dict with keys:
+        case, n_activities, cpm_duration,
+        best_serial_seed, best_parallel_seed, best_ga, improvement
+    """
+    json_path = Path(__file__).parent / json_file
+
+    print("=" * 70)
+    print(f"Case: {case_name}  ({json_file})")
+    print("=" * 70)
+
+    # ── Load and initialise Pert model ───────────────────────────────────────
+    pert = Pert.from_json_file(str(json_path), schema_path=str(SCHEMA))
+    pert.generateInfo()
+
+    cpm_duration = pert.getProjectDuration()
+    n_activities = len(pert.infoDict)
+
+    print(f"Activities      : {n_activities}")
+    print(f"CPM duration    : {cpm_duration:.2f} h  (unconstrained)")
+    print()
+
+    # ── Baseline: best duration from all named priority rules ─────────────────
+    serial_durations = {}
+    parallel_durations = {}
+
+    for rule in PRIORITY_RULES:
+        try:
+            pert.priorities = None
+            s_out = pert.calculateSerialScheduleWithResources(priority_rule=rule)
+            serial_durations[rule] = s_out['scheduled_duration'] - 2
+
+            pert.priorities = None
+            p_out = pert.calculateScheduleWithResources(
+                sgs='max_use_res_ranked', priority_rule=rule
+            )
+            parallel_durations[rule] = p_out['scheduled_duration'] - 2
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Rule '%s' skipped in baseline: %s", rule, exc)
+
+    best_serial = (
+        min(serial_durations.values()) if serial_durations else float('inf')
+    )
+    best_parallel = (
+        min(parallel_durations.values()) if parallel_durations else float('inf')
+    )
+    best_rule_overall = min(best_serial, best_parallel)
+
+    if verbose:
+        print("Priority rule baseline durations:")
+        print(f"  {'Rule':<22} {'Serial (h)':>12} {'Parallel (h)':>14}")
+        print("  " + "-" * 50)
+        for rule in PRIORITY_RULES:
+            s = serial_durations.get(rule, float('nan'))
+            p = parallel_durations.get(rule, float('nan'))
+            print(f"  {rule:<22} {s:>12.2f} {p:>14.2f}")
+        print()
+
+    # ── Run GA ───────────────────────────────────────────────────────────────
+    print(f"Running GA (crossover={crossover!r}, mutation={mutation!r}, Serial SGS)...")
+    ga = RCPSPGeneticAlgorithm(
+        pert,
+        pop_size=pop_size,
+        n_gen=n_gen,
+        cxpb=cxpb,
+        mutpb=mutpb,
+        n_random=n_random,
+        seed=seed,
+        verbose=verbose,
+        crossover=crossover,
+        mutation=mutation,
+    )
+    hof, log = ga.run()
+
+    # ── Best schedule from GA ─────────────────────────────────────────────────
+    best_result = ga.get_best_schedule(hof)
+    best_ga = best_result['scheduled_duration'] - 2
+
+    summary = ga.get_convergence_summary(log)
+    best_activity_list = ga.get_best_activity_list(hof)
+
+    print()
+    print(f"{'─' * 60}")
+    print(f"  CPM duration (unconstrained)  : {cpm_duration:.2f} h")
+    print(f"  Best serial SGS  (all rules)  : {best_serial:.2f} h")
+    print(f"  Best parallel SGS (all rules) : {best_parallel:.2f} h")
+    print(f"  Best GA duration              : {best_ga:.2f} h")
+    print(f"  Improvement over best seed    : {best_rule_overall - best_ga:.2f} h")
+    print(f"  GA improvement (gen0 → final) : {summary['improvement']:.2f} h")
+    avg_std = f"{summary['final_avg']:.2f} / {summary['final_std']:.2f}"
+    print(f"  Final avg / std               : {avg_std}")
+    print(f"{'─' * 60}")
+    first_ten = best_activity_list[:10]
+    print(f"  Best activity list (first 10) : {first_ten}")
+    print()
+
+    return {
+        'case': case_name,
+        'n_activities': n_activities,
+        'cpm_duration': cpm_duration,
+        'best_serial_seed': best_serial,
+        'best_parallel_seed': best_parallel,
+        'best_ga': best_ga,
+        'improvement': best_rule_overall - best_ga,
+    }
+
+
+def main() -> None:
+    """Run the GA on all hard j120 benchmark cases and print a summary table."""
+    best_results = load_best_known_results()
+    results = []
+    for case_name, json_file in CASES:
+        result = run_ga_case(
+            case_name=case_name,
+            json_file=json_file,
+            pop_size=50,
+            n_gen=500,
+            cxpb=0.9,
+            mutpb=0.5,
+            n_random=0,
+            seed=42,
+            verbose=False,
+            crossover='two_point',
+            mutation='consensus_reorder',
+        )
+        best_known = get_best_known_result(best_results, json_file)
+        result['best_known'] = best_known
+        result['ga_vs_best_known'] = (
+            result['best_ga'] - best_known if best_known is not None else float('nan')
+        )
+        results.append(result)
+
+    # ── Summary table ─────────────────────────────────────────────────────────
+    print("\n" + "=" * 80)
+    print("SUMMARY — GA (Activity List, two-point crossover, adjacent-swap mutation, Serial SGS)")
+    print("=" * 80)
+    print(
+        f"  {'Case':<12} {'N':>6} {'CPM (h)':>10} "
+        f"{'Best Serial':>13} {'Best Parallel':>14} {'Best GA':>10} "
+        f"{'Best Known':>12} {'GA-BK':>8} {'Δ (h)':>8}"
+    )
+    print("  " + "-" * 98)
+    for r in results:
+        print(
+            f"  {r['case']:<12} {r['n_activities']:>6} {r['cpm_duration']:>10.2f} "
+            f"{r['best_serial_seed']:>13.2f} {r['best_parallel_seed']:>14.2f} "
+            f"{r['best_ga']:>10.2f} {r['best_known']:>12.2f} "
+            f"{r['ga_vs_best_known']:>8.2f} {r['improvement']:>8.2f}"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/CPM/test_ga.py
+++ b/tests/unit_tests/CPM/test_ga.py
@@ -291,6 +291,10 @@ class TestConstructor:
         """Default mutation operator must be 'adjacent_swap'."""
         assert ga.mutation == 'adjacent_swap'
 
+    def test_default_n_random(self, ga):
+        """Default consensus-library random reference count must be 8."""
+        assert ga.n_random == 8
+
     def test_crossover_method_map(self):
         """_CROSSOVER_METHODS must contain all documented choices."""
         assert set(RCPSPGeneticAlgorithm._CROSSOVER_METHODS) == {
@@ -300,7 +304,7 @@ class TestConstructor:
     def test_mutation_method_map(self):
         """_MUTATION_METHODS must contain all documented choices."""
         assert set(RCPSPGeneticAlgorithm._MUTATION_METHODS) == {
-            'swap', 'adjacent_swap', 'insertion_window'
+            'swap', 'adjacent_swap', 'insertion_window', 'consensus_reorder'
         }
 
     def test_invalid_crossover_raises(self, pert):
@@ -325,15 +329,17 @@ class TestConstructor:
         ('uniform_order', 'insertion_window'),
         ('one_point',    'insertion_window'),
         ('uniform_order', 'swap'),
+        ('two_point',    'consensus_reorder'),
     ])
     def test_operator_selection(self, pert, cx, mut):
         """All valid crossover/mutation combinations must construct without error."""
         g = RCPSPGeneticAlgorithm(
-            pert, pop_size=3, n_gen=1, verbose=False,
+            pert, pop_size=3, n_gen=1, n_random=3, verbose=False,
             crossover=cx, mutation=mut,
         )
         assert g.crossover == cx
         assert g.mutation == mut
+        assert g.n_random == 3
 
 
 # =============================================================================
@@ -697,12 +703,13 @@ class TestRun:
         ('one_point',    'swap'),
         ('two_point',    'adjacent_swap'),
         ('uniform_order', 'insertion_window'),
+        ('two_point',    'consensus_reorder'),
     ])
     def test_all_operator_combinations_complete(self, pert, cx, mut):
         """Every valid crossover/mutation pair must complete a short run."""
         g = RCPSPGeneticAlgorithm(
             pert, pop_size=5, n_gen=2, verbose=False,
-            crossover=cx, mutation=mut, seed=0,
+            crossover=cx, mutation=mut, seed=0, n_random=3,
         )
         hof, log = g.run()
         assert len(hof) > 0


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What are the significant changes in functionality due to this change request?

# Summary

The changes span three files: [ga.py](ga.py), [ga_test.py](ga_test.py), and [ga_test_hard.py](ga_test_hard.py).

They fall into two groups:

1. summary-table enhancements using `benchmarks/best_results.json`
2. a new consensus-based mutation operator in the GA, plus constructor support for configuring its random reference pool

# 1. `ga_test.py` and `ga_test_hard.py`

Both test drivers were updated in the same way.

## Best-known result loading

Each file now:

- imports `json`
- defines `BEST_RESULTS_PATH = Path(__file__).parent / "benchmarks" / "best_results.json"`

## New helper functions

Each file now includes:

- `load_best_known_results()`
  - loads the JSON file into a dictionary
  - expects keys like `j12051_6.sm`
- `get_best_known_result(best_results, json_file)`
  - converts a benchmark JSON filename such as `j12051_6.json` into `j12051_6.sm`
  - returns the matching best-known result if present

## Main loop changes

In `main()`:

- the best-known results file is loaded once before iterating cases
- after each GA case finishes, two new result fields are added:
  - `best_known`
  - `ga_vs_best_known`

`ga_vs_best_known` is computed as:

```python
best_ga - best_known
```

So:

- positive values mean GA is worse than the best known result
- zero means GA matched the best known result
- negative values mean GA beat the stored best known result

## Summary table changes

The printed summary table in both files now includes two new columns:

- `Best Known`
- `GA-BK`

The existing columns remain:

- case
- number of activities
- CPM duration
- best serial seed
- best parallel seed
- best GA
- `Δ (h)` which still means improvement over the best seeded baseline

## Mapping verification

The filename mapping logic was checked against current cases, including:

- `j12051_6.json -> j12051_6.sm`
- `j12031_10.json -> j12031_10.sm`
- `j301_1.json -> j301_1.sm`
- `j601_1.json -> j601_1.sm`
- `j901_1.json -> j901_1.sm`
- `j1201_1.json -> j1201_1.sm`

# 2. `ga.py`

`ga.py` received the larger functional update.

## New mutation option: `consensus_reorder`

A new mutation operator was added and registered under:

```python
mutation="consensus_reorder"
```

This operator was added to `_MUTATION_METHODS`:

```python
'consensus_reorder': '_mutate_consensus_reorder'
```

## What the new mutation does

`_mutate_consensus_reorder()` is a unary mutation operator that:

- selects a local interior chromosome window
- samples several precedence-feasible reference orderings
- computes a consensus score for each gene in that window using average reference positions
- reorders only the selected window by that consensus ranking
- repairs the whole chromosome to restore precedence feasibility if needed

This is intended to capture the spirit of consensus recombination, but as a mutation rather than a crossover.

## Consensus reference library

To support that mutation, the class now builds a consensus library at construction time.

New instance state:

- `self._consensus_library`
- `self._consensus_position_maps`

New helper:

- `_build_consensus_library(...)`

It:

- gathers precedence-feasible chromosomes generated from all `PRIORITY_RULES`
- adds additional random precedence-feasible chromosomes
- deduplicates them
- stores per-chromosome position maps so consensus scores can be computed quickly

## New repair helper

A new helper was added:

```python
_repair_chromosome()
```

It centralizes precedence-feasibility repair by:

- converting the chromosome to `(Activity, rank)` pairs
- calling `pert.reorder_by_dependencies(...)`
- mapping the repaired order back to integer gene indices

This helper is now used by:

- `_mutate_swap()`
- `_mutate_consensus_reorder()`

So the old inline repair logic in `_mutate_swap()` was cleaned up and reused.

## Constructor update for consensus-library randomness

`__init__()` now accepts:

```python
n_random: int = 8
```

This value:

- is stored as `self.n_random`
- is passed into `_build_consensus_library(self.n_random)`

This makes the size of the random portion of the consensus library configurable from the GA constructor.

## Docstring updates

The class documentation was updated to reflect the new behavior:

- mutation choices now include `consensus_reorder`
- constructor parameters now document `n_random`
- the main GA loop description now says it applies the configured mutation operator rather than specifically saying “swap mutation”

# 3. Validation

The following syntax checks were run successfully:

- `python -m py_compile ga.py`

The GA benchmark scripts were not run end-to-end after these changes, so:

- syntax and integration wiring were checked
- full runtime behavior and solution-quality impact were not benchmarked in this session

# Net Effect

You now have:

- richer GA benchmark summaries that show best-known PSPLIB results and the GA gap to them
- a new consensus-guided mutation operator available in the RCPSP GA
- a configurable `n_random` constructor parameter controlling how many random reference schedules feed the consensus library

# Example usage

To use the new mutation:

```python
ga = RCPSPGeneticAlgorithm(
    pert,
    mutation="consensus_reorder",
    n_random=12,
)
```

To see the new benchmark columns, run either:

- `python ga_test.py`
- `python ga_test_hard.py`

