### PR TITLE
WIP: Multiple Heuristic Optimizer for RCPSP

### DIFF
--- a/src/CPM/analyze_ga_operator_results.py
+++ b/src/CPM/analyze_ga_operator_results.py
@@ -1,0 +1,454 @@
+"""
+analyze_ga_operator_results.py - Aggregate GA operator comparison CSVs.
+
+The operator test writes one CSV per benchmark instance.  This script processes
+those files together so crossover/mutation combinations can be compared across
+all j120 runs.
+
+Usage from the repo root:
+    python src/CPM/analyze_ga_operator_results.py
+
+Usage from the src/CPM directory:
+    python analyze_ga_operator_results.py
+
+Examples:
+    python src/CPM/analyze_ga_operator_results.py --top 6
+    python src/CPM/analyze_ga_operator_results.py --pattern "j120*.csv"
+    python src/CPM/analyze_ga_operator_results.py --no-write
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean, median
+from typing import Any
+
+
+CPM_DIR = Path(__file__).parent
+DEFAULT_RESULTS_DIR = CPM_DIR / "results" / "ga_operator_test"
+DEFAULT_PATTERN = "j120*_operator_comparison_seed*.csv"
+FILENAME_RE = re.compile(
+    r"(?P<instance>j120.*?)_operator_comparison_seed(?P<seed>\d+)\.csv$"
+)
+
+
+@dataclass(frozen=True)
+class OperatorResult:
+    source_file: str
+    instance: str
+    seed: int
+    rank: int
+    crossover: str
+    mutation: str
+    best_ga: float
+    gap_to_best_known: float
+    improvement_vs_seed: float
+    initial_best: float
+    logged_best: float
+    improvement_gen0: float
+    final_avg: float
+    final_std: float
+    n_gen_executed: int
+    n_evals: int
+    n_unique_schedules: int
+    stop_reason: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Aggregate j120 GA operator comparison CSVs and rank "
+            "crossover/mutation performance."
+        )
+    )
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=DEFAULT_RESULTS_DIR,
+        help="Directory containing per-instance operator comparison CSV files.",
+    )
+    parser.add_argument(
+        "--pattern",
+        default=DEFAULT_PATTERN,
+        help=(
+            "Input glob pattern. The default avoids re-reading aggregate output "
+            "files on later runs."
+        ),
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Directory for aggregate CSV outputs. Defaults to --input-dir.",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default="j120_operator",
+        help="Prefix for generated aggregate CSV files.",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=12,
+        help="Number of crossover/mutation combinations to print.",
+    )
+    parser.add_argument(
+        "--no-write",
+        action="store_true",
+        help="Print summaries without writing aggregate CSV files.",
+    )
+    return parser.parse_args()
+
+
+def _to_float(value: str | None) -> float:
+    if value is None:
+        return float("nan")
+    stripped = value.strip()
+    if not stripped:
+        return float("nan")
+    return float(stripped)
+
+
+def _to_int(value: str | None) -> int:
+    return int(round(_to_float(value)))
+
+
+def _mean(values: list[float]) -> float:
+    finite = [value for value in values if math.isfinite(value)]
+    return mean(finite) if finite else float("nan")
+
+
+def _median(values: list[float]) -> float:
+    finite = [value for value in values if math.isfinite(value)]
+    return median(finite) if finite else float("nan")
+
+
+def _fmt(value: float, digits: int = 2) -> str:
+    if not math.isfinite(value):
+        return "nan"
+    return f"{value:.{digits}f}"
+
+
+def _file_context(path: Path) -> tuple[str, int] | None:
+    match = FILENAME_RE.match(path.name)
+    if not match:
+        return None
+    return match.group("instance"), int(match.group("seed"))
+
+
+def read_result_file(path: Path) -> list[OperatorResult]:
+    context = _file_context(path)
+    if context is None:
+        return []
+
+    instance, seed = context
+    rows: list[OperatorResult] = []
+    with path.open("r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(
+                OperatorResult(
+                    source_file=path.name,
+                    instance=instance,
+                    seed=seed,
+                    rank=_to_int(row.get("rank")),
+                    crossover=(row.get("crossover") or "").strip(),
+                    mutation=(row.get("mutation") or "").strip(),
+                    best_ga=_to_float(row.get("best_ga")),
+                    gap_to_best_known=_to_float(row.get("gap_to_best_known")),
+                    improvement_vs_seed=_to_float(row.get("improvement_vs_seed")),
+                    initial_best=_to_float(row.get("initial_best")),
+                    logged_best=_to_float(row.get("logged_best")),
+                    improvement_gen0=_to_float(row.get("improvement_gen0")),
+                    final_avg=_to_float(row.get("final_avg")),
+                    final_std=_to_float(row.get("final_std")),
+                    n_gen_executed=_to_int(row.get("n_gen_executed")),
+                    n_evals=_to_int(row.get("n_evals")),
+                    n_unique_schedules=_to_int(row.get("n_unique_schedules")),
+                    stop_reason=(row.get("stop_reason") or "").strip(),
+                )
+            )
+    return rows
+
+
+def load_results(input_dir: Path, pattern: str) -> tuple[list[OperatorResult], list[Path]]:
+    paths = sorted(input_dir.glob(pattern))
+    rows: list[OperatorResult] = []
+    skipped: list[Path] = []
+    for path in paths:
+        if _file_context(path) is None:
+            skipped.append(path)
+            continue
+        rows.extend(read_result_file(path))
+    return rows, skipped
+
+
+def _group_key(row: OperatorResult, fields: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(str(getattr(row, field)) for field in fields)
+
+
+def summarize(
+    rows: list[OperatorResult],
+    fields: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, ...], list[OperatorResult]] = defaultdict(list)
+    for row in rows:
+        grouped[_group_key(row, fields)].append(row)
+
+    summaries: list[dict[str, Any]] = []
+    for key, group in grouped.items():
+        wins = [row for row in group if row.rank == 1]
+        stop_reasons = Counter(row.stop_reason for row in group)
+        summary: dict[str, Any] = {
+            field: value for field, value in zip(fields, key, strict=True)
+        }
+        summary.update(
+            {
+                "runs": len(group),
+                "instances": len({row.instance for row in group}),
+                "seeds": len({row.seed for row in group}),
+                "wins": len(wins),
+                "top3": sum(row.rank <= 3 for row in group),
+                "win_rate": len(wins) / len(group),
+                "top3_rate": sum(row.rank <= 3 for row in group) / len(group),
+                "avg_rank": _mean([float(row.rank) for row in group]),
+                "median_rank": _median([float(row.rank) for row in group]),
+                "avg_best_ga": _mean([row.best_ga for row in group]),
+                "avg_gap_to_best_known": _mean(
+                    [row.gap_to_best_known for row in group]
+                ),
+                "avg_improvement_vs_seed": _mean(
+                    [row.improvement_vs_seed for row in group]
+                ),
+                "avg_logged_best": _mean([row.logged_best for row in group]),
+                "avg_final_avg": _mean([row.final_avg for row in group]),
+                "avg_final_std": _mean([row.final_std for row in group]),
+                "avg_n_gen_executed": _mean(
+                    [float(row.n_gen_executed) for row in group]
+                ),
+                "avg_n_evals": _mean([float(row.n_evals) for row in group]),
+                "winning_instances": ", ".join(
+                    sorted({row.instance for row in wins})
+                ),
+                "stop_reasons": "; ".join(
+                    f"{reason}:{count}"
+                    for reason, count in sorted(stop_reasons.items())
+                ),
+            }
+        )
+        summaries.append(summary)
+
+    summaries.sort(key=summary_sort_key)
+    return summaries
+
+
+def summary_sort_key(summary: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        summary["avg_rank"],
+        summary["avg_gap_to_best_known"],
+        summary["avg_best_ga"],
+        -summary["wins"],
+        summary.get("crossover", ""),
+        summary.get("mutation", ""),
+    )
+
+
+def write_rows(rows: list[OperatorResult], path: Path) -> None:
+    fields = list(OperatorResult.__dataclass_fields__)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: getattr(row, field) for field in fields})
+
+
+def write_summary(summaries: list[dict[str, Any]], path: Path) -> None:
+    if not summaries:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fields = list(summaries[0])
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(summaries)
+
+
+def write_matrix(
+    combo_summaries: list[dict[str, Any]],
+    metric: str,
+    path: Path,
+) -> None:
+    crossovers = sorted({summary["crossover"] for summary in combo_summaries})
+    mutations = sorted({summary["mutation"] for summary in combo_summaries})
+    lookup = {
+        (summary["crossover"], summary["mutation"]): summary
+        for summary in combo_summaries
+    }
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["crossover", *mutations])
+        for crossover in crossovers:
+            row = [crossover]
+            for mutation in mutations:
+                value = lookup.get((crossover, mutation), {}).get(metric)
+                row.append("" if value is None else _fmt(float(value), digits=4))
+            writer.writerow(row)
+
+
+def print_combo_summary(summaries: list[dict[str, Any]], top: int) -> None:
+    print()
+    print("CROSSOVER + MUTATION COMBINATION SUMMARY")
+    print("-" * 104)
+    print(
+        f"{'#':>2} {'Crossover':<14} {'Mutation':<18} {'Runs':>4} "
+        f"{'Wins':>4} {'Top3':>4} {'AvgRank':>8} {'AvgGap':>8} "
+        f"{'AvgBest':>8} {'AvgSeed+':>9}"
+    )
+    print("-" * 104)
+    for idx, summary in enumerate(summaries[:top], start=1):
+        print(
+            f"{idx:>2} {summary['crossover']:<14} {summary['mutation']:<18} "
+            f"{summary['runs']:>4} {summary['wins']:>4} {summary['top3']:>4} "
+            f"{_fmt(summary['avg_rank']):>8} "
+            f"{_fmt(summary['avg_gap_to_best_known']):>8} "
+            f"{_fmt(summary['avg_best_ga']):>8} "
+            f"{_fmt(summary['avg_improvement_vs_seed']):>9}"
+        )
+    print("-" * 104)
+
+
+def print_single_operator_summary(
+    title: str,
+    summaries: list[dict[str, Any]],
+    field: str,
+) -> None:
+    print()
+    print(title)
+    print("-" * 82)
+    print(
+        f"{field.title():<18} {'Runs':>4} {'Wins':>4} {'Top3':>4} "
+        f"{'AvgRank':>8} {'AvgGap':>8} {'AvgBest':>8} {'AvgSeed+':>9}"
+    )
+    print("-" * 82)
+    for summary in summaries:
+        print(
+            f"{summary[field]:<18} {summary['runs']:>4} "
+            f"{summary['wins']:>4} {summary['top3']:>4} "
+            f"{_fmt(summary['avg_rank']):>8} "
+            f"{_fmt(summary['avg_gap_to_best_known']):>8} "
+            f"{_fmt(summary['avg_best_ga']):>8} "
+            f"{_fmt(summary['avg_improvement_vs_seed']):>9}"
+        )
+    print("-" * 82)
+
+
+def print_winners(rows: list[OperatorResult]) -> None:
+    winners = sorted((row for row in rows if row.rank == 1), key=lambda r: r.instance)
+    if not winners:
+        return
+
+    print()
+    print("PER-INSTANCE WINNERS")
+    print("-" * 86)
+    print(
+        f"{'Instance':<12} {'Seed':>4} {'Crossover':<14} {'Mutation':<18} "
+        f"{'Best':>8} {'BK Gap':>8}"
+    )
+    print("-" * 86)
+    for row in winners:
+        print(
+            f"{row.instance:<12} {row.seed:>4} {row.crossover:<14} "
+            f"{row.mutation:<18} {_fmt(row.best_ga):>8} "
+            f"{_fmt(row.gap_to_best_known):>8}"
+        )
+    print("-" * 86)
+
+
+def write_outputs(
+    rows: list[OperatorResult],
+    combo_summaries: list[dict[str, Any]],
+    crossover_summaries: list[dict[str, Any]],
+    mutation_summaries: list[dict[str, Any]],
+    output_dir: Path,
+    prefix: str,
+) -> list[Path]:
+    paths = {
+        "all_rows": output_dir / f"{prefix}_all_rows.csv",
+        "combo_summary": output_dir / f"{prefix}_combo_summary.csv",
+        "crossover_summary": output_dir / f"{prefix}_crossover_summary.csv",
+        "mutation_summary": output_dir / f"{prefix}_mutation_summary.csv",
+        "avg_rank_matrix": output_dir / f"{prefix}_avg_rank_matrix.csv",
+        "avg_gap_matrix": output_dir / f"{prefix}_avg_gap_matrix.csv",
+    }
+
+    write_rows(rows, paths["all_rows"])
+    write_summary(combo_summaries, paths["combo_summary"])
+    write_summary(crossover_summaries, paths["crossover_summary"])
+    write_summary(mutation_summaries, paths["mutation_summary"])
+    write_matrix(combo_summaries, "avg_rank", paths["avg_rank_matrix"])
+    write_matrix(combo_summaries, "avg_gap_to_best_known", paths["avg_gap_matrix"])
+    return list(paths.values())
+
+
+def main() -> None:
+    args = parse_args()
+    rows, skipped = load_results(args.input_dir, args.pattern)
+
+    if not rows:
+        raise SystemExit(
+            f"No operator comparison rows found in {args.input_dir} "
+            f"with pattern {args.pattern!r}."
+        )
+
+    combo_summaries = summarize(rows, ("crossover", "mutation"))
+    crossover_summaries = summarize(rows, ("crossover",))
+    mutation_summaries = summarize(rows, ("mutation",))
+
+    instances = sorted({row.instance for row in rows})
+    seeds = sorted({row.seed for row in rows})
+    print("=" * 86)
+    print("GA OPERATOR RESULT AGGREGATION")
+    print("=" * 86)
+    print(f"Input directory : {args.input_dir}")
+    print(f"Input pattern   : {args.pattern}")
+    print(f"Instances       : {len(instances)}")
+    print(f"Seeds           : {', '.join(str(seed) for seed in seeds)}")
+    print(f"Rows            : {len(rows)}")
+    if skipped:
+        print(f"Skipped files   : {len(skipped)} unmatched file name(s)")
+
+    print_combo_summary(combo_summaries, args.top)
+    print_single_operator_summary(
+        "CROSSOVER SUMMARY", crossover_summaries, "crossover"
+    )
+    print_single_operator_summary("MUTATION SUMMARY", mutation_summaries, "mutation")
+    print_winners(rows)
+
+    if args.no_write:
+        return
+
+    output_dir = args.output_dir or args.input_dir
+    paths = write_outputs(
+        rows,
+        combo_summaries,
+        crossover_summaries,
+        mutation_summaries,
+        output_dir,
+        args.output_prefix,
+    )
+    print()
+    print("Wrote aggregate CSV files:")
+    for path in paths:
+        print(f"  {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CPM/ga.py
+++ b/src/CPM/ga.py
@@ -154,6 +154,14 @@ class RCPSPGeneticAlgorithm:
         * ``'adjacent_swap'``     — adjacent-swap with feasibility check (default)
         * ``'insertion_window'``  — precedence-window insertion
         * ``'consensus_reorder'`` — local reorder guided by consensus references
+    fb_improvement : bool
+        Apply Forward-Backward-Forward (FBF) local improvement (Valls et al., 2005)
+        as a final polish on the full population after evolution completes, then
+        update the Hall of Fame from the improved population.  Default ``True``.
+    fb_freq : int
+        If > 0, also apply FBF every ``fb_freq`` generations during evolution
+        (applied to the whole population).  ``0`` (default) disables periodic
+        in-run application and limits FBF to the final polishing step.
     """
 
     # DEAP creator type names (module-level singletons; guarded against
@@ -188,6 +196,8 @@ class RCPSPGeneticAlgorithm:
         verbose: bool = True,
         crossover: str = 'two_point',
         mutation: str = 'adjacent_swap',
+        fb_improvement: bool = True,
+        fb_freq: int = 0,
     ) -> None:
         if crossover not in self._CROSSOVER_METHODS:
             raise ValueError(
@@ -222,6 +232,8 @@ class RCPSPGeneticAlgorithm:
         self.verbose = verbose
         self.crossover = crossover
         self.mutation = mutation
+        self.fb_improvement = fb_improvement
+        self.fb_freq = fb_freq
 
         random.seed(seed)
         np.random.seed(seed)
@@ -351,6 +363,127 @@ class RCPSPGeneticAlgorithm:
             {gene: pos for pos, gene in enumerate(chromosome)}
             for chromosome in references
         ]
+
+    # ---------------------------------------------------------------------- #
+    # Forward-Backward-Forward (FBF) improvement                               #
+    # ---------------------------------------------------------------------- #
+
+    def _compute_backward_chromosome(
+        self, forward_chromosome: List[int]
+    ) -> Tuple[List[int], float]:
+        """
+        Run a forward SGS pass, compute ALAP times by backward sweep,
+        and return a new chromosome sorted by ALAP late-start.
+
+        This is the 'F→B' leg of Forward-Backward-Forward improvement.
+
+        After the forward schedule the successor start-times are used to
+        tighten the ALAP bound for each activity:
+
+            alap_lf(a)  =  min(alap_ls(s)  for s in successors(a))
+                           or makespan if a has no successors
+            alap_ls(a)  =  alap_lf(a) − duration(a)
+
+        Activities are then sorted by alap_ls (ascending) and repaired for
+        precedence feasibility via ``reorder_by_dependencies``.
+
+        Parameters
+        ----------
+        forward_chromosome : list of int
+            Precedence-feasible activity index permutation used for the
+            forward SGS call.
+
+        Returns
+        -------
+        backward_chromosome : list of int
+        makespan_h : float
+            Raw ``scheduled_duration`` (hours) from the forward SGS call.
+        """
+        acts = self._chromosome_to_activities(forward_chromosome)
+        out = self.pert.calculateSerialScheduleWithResources(_ordered=acts)
+        makespan_h: float = out['scheduled_duration']
+
+        # Backward ALAP sweep — pure precedence, no resource constraints.
+        # Iterate in reverse topological order; every successor is already
+        # processed so alap_ls[s] is available when we handle activity a.
+        alap_ls: Dict[Any, float] = {}
+        for gene in reversed(forward_chromosome):
+            a = self._activities[gene]
+            d = self.pert.infoDict[a]['duration']
+            succs = self.pert.forwardDict.get(a, [])
+            succ_ls = [alap_ls[s] for s in succs if s in alap_ls]
+            alap_lf = min(succ_ls) if succ_ls else makespan_h
+            alap_ls[a] = alap_lf - d
+
+        # Reorder by ALAP late-start; repair for precedence feasibility.
+        ranked = [(a, alap_ls.get(a, 0.0)) for a in self._activities]
+        repaired = self.pert.reorder_by_dependencies(ranked, self.pert.forwardDict)
+        backward_chromosome = [self._act_to_idx[a] for a, _ in repaired]
+        return backward_chromosome, makespan_h
+
+    def _fb_improvement(
+        self, chromosome: List[int]
+    ) -> Tuple[List[int], float]:
+        """
+        One Forward-Backward-Forward (FBF) improvement pass.
+
+        Algorithm (Valls, Ballestin, Quintanilla 2005):
+
+        F1  Serial SGS with *chromosome* → scheduled start-times, makespan T₁.
+        B   ALAP backward sweep using T₁ as the backward horizon and the
+            actual forward-scheduled successor times to derive tight ALAP
+            bounds → new precedence-feasible ordering λ_B.
+        F2  Serial SGS with λ_B → makespan T₂.
+
+        Returns whichever of (chromosome, T₁) or (λ_B, T₂) has the smaller
+        makespan, so the operator can never worsen a solution.
+
+        Parameters
+        ----------
+        chromosome : list of int
+
+        Returns
+        -------
+        best_chromosome : list of int
+        best_fitness    : float   (scheduled_duration − 2)
+        """
+        backward_chromosome, makespan_f1 = self._compute_backward_chromosome(
+            chromosome
+        )
+        fitness_f1 = makespan_f1 - 2
+
+        acts_b = self._chromosome_to_activities(backward_chromosome)
+        out_f2 = self.pert.calculateSerialScheduleWithResources(_ordered=acts_b)
+        fitness_f2 = out_f2['scheduled_duration'] - 2
+
+        if fitness_f2 <= fitness_f1:
+            return backward_chromosome, fitness_f2
+        return chromosome, fitness_f1
+
+    def apply_fb_improvement(self, individuals: List[Any]) -> int:
+        """
+        Apply Forward-Backward-Forward improvement in-place to a sequence of
+        DEAP individuals, updating each individual and its stored fitness when
+        a shorter schedule is found.
+
+        Parameters
+        ----------
+        individuals : list of IndividualRCPSP
+            Typically ``pop`` (the full population) or ``list(hof)``.
+
+        Returns
+        -------
+        n_improved : int
+            Number of individuals whose fitness was strictly improved.
+        """
+        n_improved = 0
+        for ind in individuals:
+            new_chr, new_fit = self._fb_improvement(list(ind))
+            if new_fit < ind.fitness.values[0]:
+                ind[:] = new_chr
+                ind.fitness.values = (new_fit,)
+                n_improved += 1
+        return n_improved
 
     # ---------------------------------------------------------------------- #
     # Initial population                                                       #
@@ -965,6 +1098,8 @@ class RCPSPGeneticAlgorithm:
         -------
         hof : deap.tools.HallOfFame
             Top ``hof_size`` individuals found across all generations.
+            When ``fb_improvement=True`` the HoF individuals are polished
+            by a final FBF pass before being returned.
         log : deap.tools.Logbook
             Per-generation statistics:
             ``gen``, ``nevals``, ``min``, ``avg``, ``std``, ``max``.
@@ -1022,10 +1157,37 @@ class RCPSPGeneticAlgorithm:
             pop[:] = offspring
             hof.update(pop)
 
+            # Periodic FBF improvement (optional)
+            if self.fb_improvement and self.fb_freq > 0 and gen % self.fb_freq == 0:
+                n_fb = self.apply_fb_improvement(pop)
+                hof.update(pop)
+                if self.verbose and n_fb:
+                    print(
+                        f"  [FBF gen {gen}] {n_fb}/{len(pop)} improved"
+                        f" | best = {hof[0].fitness.values[0]:.2f} h"
+                    )
+
             record = stats.compile(pop)
             log.record(gen=gen, nevals=len(invalid), **record)
             if self.verbose:
                 print(log.stream)
+
+        # Final FBF polish on the full population; update HoF from result
+        if self.fb_improvement:
+            n_fb = self.apply_fb_improvement(pop)
+            hof.update(pop)
+            if self.verbose:
+                msg = (
+                    f"FBF final polish: {n_fb}/{len(pop)} improved"
+                    f" | best = {hof[0].fitness.values[0]:.2f} h"
+                )
+                print(f"\n{msg}")
+            logger.info(
+                "FBF final polish: %d/%d improved | best = %.2f h",
+                n_fb,
+                len(pop),
+                hof[0].fitness.values[0],
+            )
 
         logger.info(
             "GA finished | best = %.2f h | generations = %d | pop_size = %d",

--- a/src/CPM/ga.py
+++ b/src/CPM/ga.py
@@ -133,6 +133,9 @@ class RCPSPGeneticAlgorithm:
         Probability of applying crossover to a selected pair of parents.
     seed : int
         RNG seed for reproducibility.
+    n_random : int
+        Number of additional random precedence-feasible reference orderings
+        to include in the consensus library.
     hof_size : int
         Number of elite individuals kept in the Hall of Fame across all
         generations.
@@ -150,6 +153,7 @@ class RCPSPGeneticAlgorithm:
         * ``'swap'``              — random swap with topological repair
         * ``'adjacent_swap'``     — adjacent-swap with feasibility check (default)
         * ``'insertion_window'``  — precedence-window insertion
+        * ``'consensus_reorder'`` — local reorder guided by consensus references
     """
 
     # DEAP creator type names (module-level singletons; guarded against
@@ -168,6 +172,7 @@ class RCPSPGeneticAlgorithm:
         'swap':             '_mutate_swap',
         'adjacent_swap':    '_mutate_adjacent_swap',
         'insertion_window': '_mutate_insertion_window',
+        'consensus_reorder': '_mutate_consensus_reorder',
     }
 
     def __init__(
@@ -178,6 +183,7 @@ class RCPSPGeneticAlgorithm:
         cxpb: float = 0.7,
         mutpb: float = 0.1,
         seed: int = 42,
+        n_random: int = 8,
         hof_size: int = 5,
         verbose: bool = True,
         crossover: str = 'two_point',
@@ -199,6 +205,7 @@ class RCPSPGeneticAlgorithm:
         self.n_gen = n_gen
         self.cxpb = cxpb
         self.mutpb = mutpb
+        self.n_random = n_random
         self.hof_size = hof_size
         self.verbose = verbose
         self.crossover = crossover
@@ -213,8 +220,11 @@ class RCPSPGeneticAlgorithm:
         self._act_to_idx: Dict[Any, int] = {
             a: i for i, a in enumerate(self._activities)
         }
+        self._consensus_library: List[List[int]] = []
+        self._consensus_position_maps: List[Dict[int, int]] = []
 
         self._setup_deap()
+        self._build_consensus_library(self.n_random)
 
     # ---------------------------------------------------------------------- #
     # DEAP registration                                                        #
@@ -283,6 +293,52 @@ class RCPSPGeneticAlgorithm:
     def _chromosome_to_activities(self, chromosome: List[int]) -> List[Any]:
         """Convert an index-list chromosome to an ordered list of Activity objects."""
         return [self._activities[i] for i in chromosome]
+
+    def _repair_chromosome(self, chromosome: List[int]) -> List[int]:
+        """
+        Restore precedence feasibility while preserving the perturbed order
+        as closely as possible.
+        """
+        acts = self._chromosome_to_activities(chromosome)
+        ranked = [(a, pos) for pos, a in enumerate(acts)]
+        repaired = self.pert.reorder_by_dependencies(ranked, self.pert.forwardDict)
+        return [self._act_to_idx[a] for a, _ in repaired]
+
+    def _build_consensus_library(self, n_random: int) -> None:
+        """
+        Build a small library of precedence-feasible reference orderings used
+        by consensus-guided mutation.
+        """
+        references: List[List[int]] = []
+        seen: set[Tuple[int, ...]] = set()
+
+        for rule in PRIORITY_RULES:
+            try:
+                chromosome = self._rule_to_chromosome(rule)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "Skipping rule '%s' in consensus library construction: %s",
+                    rule,
+                    exc,
+                )
+                continue
+            key = tuple(chromosome)
+            if key not in seen:
+                references.append(chromosome)
+                seen.add(key)
+
+        for _ in range(n_random):
+            chromosome = self._rule_to_chromosome('random')
+            key = tuple(chromosome)
+            if key not in seen:
+                references.append(chromosome)
+                seen.add(key)
+
+        self._consensus_library = references
+        self._consensus_position_maps = [
+            {gene: pos for pos, gene in enumerate(chromosome)}
+            for chromosome in references
+        ]
 
     # ---------------------------------------------------------------------- #
     # Initial population                                                       #
@@ -656,13 +712,7 @@ class RCPSPGeneticAlgorithm:
         # Build (Activity, rank) pairs from the perturbed ordering.
         # rank = position index so reorder_by_dependencies preserves the swap
         # wherever precedence allows it.
-        acts = self._chromosome_to_activities(individual)
-        ranked = [(a, pos) for pos, a in enumerate(acts)]
-
-        # Repair to topological feasibility.
-        repaired = self.pert.reorder_by_dependencies(ranked, self.pert.forwardDict)
-
-        individual[:] = [self._act_to_idx[a] for a, _ in repaired]
+        individual[:] = self._repair_chromosome(individual)
         return (individual,)
 
     def _mutate_adjacent_swap(
@@ -797,6 +847,64 @@ class RCPSPGeneticAlgorithm:
 
         return (individual,)
 
+    def _mutate_consensus_reorder(self, individual: List[int]) -> Tuple[List[int]]:
+        """
+        Consensus-guided block reorder mutation.
+
+        The operator perturbs a local window of the chromosome using a
+        consensus ranking induced by several reference orderings. This follows
+        the spirit of consensus recombination: preserve agreements that recur
+        across multiple good precedence-feasible schedules, but apply them as
+        a unary mutation to a single individual.
+
+        Algorithm
+        ---------
+        1. Select a random interior window [lo..hi] of non-dummy genes.
+        2. Sample a small number of precedence-feasible reference orderings
+           from the consensus library.
+        3. For each gene in the window, compute its average position across
+           the sampled references.
+        4. Reorder only the genes inside the window by that consensus score,
+           breaking ties by the current order.
+        5. Apply topological repair to restore precedence feasibility if the
+           local reorder conflicts with dependency constraints.
+
+        Returns
+        -------
+        tuple
+            ``(individual,)`` — single-element tuple per DEAP convention.
+        """
+        n = len(individual)
+        if n < 6 or not self._consensus_position_maps:
+            return (individual,)
+
+        interior_positions = list(range(1, n - 1))
+        if len(interior_positions) < 3:
+            return (individual,)
+
+        max_window = min(8, len(interior_positions))
+        window_len = random.randint(3, max_window)
+        lo = random.randint(1, n - 1 - window_len)
+        hi = lo + window_len
+
+        current_window = individual[lo:hi]
+        current_rank = {gene: offset for offset, gene in enumerate(current_window)}
+
+        sample_size = min(5, len(self._consensus_position_maps))
+        sampled_maps = random.sample(self._consensus_position_maps, sample_size)
+
+        def consensus_score(gene: int) -> Tuple[float, int]:
+            avg_pos = sum(pos_map[gene] for pos_map in sampled_maps) / sample_size
+            return avg_pos, current_rank[gene]
+
+        reordered_window = sorted(current_window, key=consensus_score)
+        if reordered_window == current_window:
+            return (individual,)
+
+        individual[lo:hi] = reordered_window
+        individual[:] = self._repair_chromosome(individual)
+        return (individual,)
+
     # ---------------------------------------------------------------------- #
     # Main optimisation loop                                                   #
     # ---------------------------------------------------------------------- #
@@ -812,7 +920,7 @@ class RCPSPGeneticAlgorithm:
         3. For each of ``n_gen`` generations:
            a. Tournament selection.
            b. Pairwise crossover with probability ``cxpb``.
-           c. Swap mutation with probability ``mutpb``.
+           c. Apply the configured mutation operator with probability ``mutpb``.
            d. Re-evaluate invalidated offspring.
            d. Generational replacement.
            e. Update Hall of Fame and statistics logbook.

--- a/src/CPM/ga.py
+++ b/src/CPM/ga.py
@@ -162,6 +162,28 @@ class RCPSPGeneticAlgorithm:
         If > 0, also apply FBF every ``fb_freq`` generations during evolution
         (applied to the whole population).  ``0`` (default) disables periodic
         in-run application and limits FBF to the final polishing step.
+    target_fitness : float, optional
+        Stop once the Hall-of-Fame best fitness is less than or equal to this
+        value.  Useful when a PSPLIB optimum or accepted target makespan is
+        known.
+    max_evals : int, optional
+        Stop before starting a generation that would exceed this many GA
+        fitness evaluations.  This counts calls to the serial SGS decoder made
+        by ``_evaluate``; FBF local-improvement calls are not counted, so set
+        ``fb_improvement=False`` for a strict decoder-call budget.
+    stall_generations : int, optional
+        Stop after this many consecutive generations without a Hall-of-Fame
+        improvement larger than ``stall_tolerance``.
+    stall_tolerance : float
+        Minimum decrease in best fitness required to reset the stall counter.
+    fitness_std_tol : float, optional
+        Stop when population fitness standard deviation remains at or below
+        this threshold for ``std_generations`` consecutive generations.
+    std_generations : int
+        Consecutive low-variance generations required by ``fitness_std_tol``.
+    max_unique_schedules : int, optional
+        Stop after observing this many unique decoded start-time schedules.
+        Schedule uniqueness is tracked only when this option is supplied.
     """
 
     # DEAP creator type names (module-level singletons; guarded against
@@ -198,6 +220,13 @@ class RCPSPGeneticAlgorithm:
         mutation: str = 'adjacent_swap',
         fb_improvement: bool = True,
         fb_freq: int = 0,
+        target_fitness: Optional[float] = None,
+        max_evals: Optional[int] = None,
+        stall_generations: Optional[int] = None,
+        stall_tolerance: float = 1e-9,
+        fitness_std_tol: Optional[float] = None,
+        std_generations: int = 1,
+        max_unique_schedules: Optional[int] = None,
     ) -> None:
         if crossover not in self._CROSSOVER_METHODS:
             raise ValueError(
@@ -221,6 +250,18 @@ class RCPSPGeneticAlgorithm:
             raise ValueError("n_random must be non-negative.")
         if hof_size <= 0:
             raise ValueError("hof_size must be positive.")
+        if max_evals is not None and max_evals < pop_size:
+            raise ValueError("max_evals must be at least pop_size.")
+        if stall_generations is not None and stall_generations <= 0:
+            raise ValueError("stall_generations must be positive when supplied.")
+        if stall_tolerance < 0:
+            raise ValueError("stall_tolerance must be non-negative.")
+        if fitness_std_tol is not None and fitness_std_tol < 0:
+            raise ValueError("fitness_std_tol must be non-negative when supplied.")
+        if std_generations <= 0:
+            raise ValueError("std_generations must be positive.")
+        if max_unique_schedules is not None and max_unique_schedules <= 0:
+            raise ValueError("max_unique_schedules must be positive when supplied.")
 
         self.pert = pert
         self.pop_size = pop_size
@@ -234,6 +275,18 @@ class RCPSPGeneticAlgorithm:
         self.mutation = mutation
         self.fb_improvement = fb_improvement
         self.fb_freq = fb_freq
+        self.target_fitness = target_fitness
+        self.max_evals = max_evals
+        self.stall_generations = stall_generations
+        self.stall_tolerance = stall_tolerance
+        self.fitness_std_tol = fitness_std_tol
+        self.std_generations = std_generations
+        self.max_unique_schedules = max_unique_schedules
+        self.stop_reason: Optional[str] = None
+
+        self._eval_count = 0
+        self._unique_schedule_signatures: set[Tuple[Tuple[int, Optional[float]], ...]] = set()
+        self._track_unique_schedules = max_unique_schedules is not None
 
         random.seed(seed)
         np.random.seed(seed)
@@ -606,6 +659,45 @@ class RCPSPGeneticAlgorithm:
     # Fitness evaluation                                                       #
     # ---------------------------------------------------------------------- #
 
+    def _reset_run_counters(self) -> None:
+        """Reset counters used by optional stopping criteria."""
+        self.stop_reason = None
+        self._eval_count = 0
+        self._unique_schedule_signatures = set()
+        self._track_unique_schedules = self.max_unique_schedules is not None
+
+    def _schedule_signature(self) -> Tuple[Tuple[int, Optional[float]], ...]:
+        """
+        Canonical start-time signature for the schedule left by the SGS decoder.
+
+        Two chromosomes can decode to the same start-time schedule.  The
+        optional ``max_unique_schedules`` stopping rule follows that schedule
+        space rather than raw chromosome count.
+        """
+        project_start = getattr(self.pert, 'startTime', None)
+        signature: List[Tuple[int, Optional[float]]] = []
+        for idx, act in enumerate(self._activities):
+            start_time = getattr(act, 'startTime', None)
+            if project_start is None or start_time is None:
+                offset = None
+            else:
+                offset = round(
+                    (start_time - project_start).total_seconds() / 3600.0,
+                    9,
+                )
+            signature.append((idx, offset))
+        return tuple(signature)
+
+    def _note_fitness_evaluation(self) -> None:
+        """Update evaluation and unique-schedule counters after SGS decoding."""
+        self._eval_count += 1
+        if self._track_unique_schedules:
+            self._unique_schedule_signatures.add(self._schedule_signature())
+
+    def _unique_schedule_count(self) -> int:
+        """Number of unique decoded schedules tracked in this run."""
+        return len(self._unique_schedule_signatures)
+
     def _evaluate(self, individual: List[int]) -> Tuple[float, ...]:
         """
         Decode an activity list chromosome and evaluate fitness using the
@@ -630,6 +722,7 @@ class RCPSPGeneticAlgorithm:
         """
         ordered_acts = self._chromosome_to_activities(individual)
         out = self.pert.calculateSerialScheduleWithResources(_ordered=ordered_acts)
+        self._note_fitness_evaluation()
         return (out['scheduled_duration'] - 2,)
 
     # ---------------------------------------------------------------------- #
@@ -1078,6 +1171,28 @@ class RCPSPGeneticAlgorithm:
     # Main optimisation loop                                                   #
     # ---------------------------------------------------------------------- #
 
+    def _stopping_reason(
+        self,
+        best_fitness: float,
+        stall: int,
+        std_stall: int,
+    ) -> Optional[str]:
+        """Return the active stopping reason, if an optional criterion fired."""
+        if self.target_fitness is not None and best_fitness <= self.target_fitness:
+            return 'target_fitness'
+        if (
+            self.max_unique_schedules is not None
+            and self._unique_schedule_count() >= self.max_unique_schedules
+        ):
+            return 'max_unique_schedules'
+        if self.max_evals is not None and self._eval_count >= self.max_evals:
+            return 'max_evals'
+        if self.stall_generations is not None and stall >= self.stall_generations:
+            return 'stall_generations'
+        if self.fitness_std_tol is not None and std_stall >= self.std_generations:
+            return 'fitness_std_tol'
+        return None
+
     def run(self) -> Tuple[tools.HallOfFame, tools.Logbook]:
         """
         Execute the genetic algorithm.
@@ -1102,9 +1217,12 @@ class RCPSPGeneticAlgorithm:
             by a final FBF pass before being returned.
         log : deap.tools.Logbook
             Per-generation statistics:
-            ``gen``, ``nevals``, ``min``, ``avg``, ``std``, ``max``.
+            ``gen``, ``nevals``, ``evals``, ``best``, ``stall``,
+            ``unique_schedules``, ``stop_reason``, ``min``, ``avg``, ``std``,
+            ``max``.
         """
         # ── Generation 0 ─────────────────────────────────────────────────────
+        self._reset_run_counters()
         pop = self.generate_initial_population()
         if not pop:
             raise RuntimeError("Initial population is empty; GA cannot run.")
@@ -1121,56 +1239,118 @@ class RCPSPGeneticAlgorithm:
         stats.register("max", np.max)
 
         log = tools.Logbook()
-        log.header = ["gen", "nevals"] + stats.fields
+        log.header = [
+            "gen", "nevals", "evals", "best", "stall",
+            "unique_schedules", "stop_reason",
+        ] + stats.fields
         hof.update(pop)
         record = stats.compile(pop)
-        log.record(gen=0, nevals=len(pop), **record)
+        best_ever = hof[0].fitness.values[0]
+        stall = 0
+        std_stall = (
+            1
+            if self.fitness_std_tol is not None
+            and record['std'] <= self.fitness_std_tol
+            else 0
+        )
+        stop_reason = self._stopping_reason(best_ever, stall, std_stall)
+        log.record(
+            gen=0,
+            nevals=len(pop),
+            evals=self._eval_count,
+            best=best_ever,
+            stall=stall,
+            unique_schedules=self._unique_schedule_count(),
+            stop_reason=stop_reason or '',
+            **record,
+        )
         if self.verbose:
             print(log.stream)
 
         # ── Generational loop ─────────────────────────────────────────────────
-        for gen in range(1, self.n_gen + 1):
-            # Selection
-            offspring = list(
-                map(self.toolbox.clone, self.toolbox.select(pop, len(pop)))
-            )
+        if stop_reason is None:
+            for gen in range(1, self.n_gen + 1):
+                if self.max_evals is not None and self._eval_count >= self.max_evals:
+                    stop_reason = 'max_evals'
+                    break
 
-            # Crossover
-            for child1, child2 in zip(offspring[::2], offspring[1::2]):
-                if random.random() < self.cxpb:
-                    self.toolbox.mate(child1, child2)
-                    del child1.fitness.values
-                    del child2.fitness.values
+                # Selection
+                offspring = list(
+                    map(self.toolbox.clone, self.toolbox.select(pop, len(pop)))
+                )
 
-            # Mutation
-            for mutant in offspring:
-                if random.random() < self.mutpb:
-                    self.toolbox.mutate(mutant)
-                    del mutant.fitness.values
+                # Crossover
+                for child1, child2 in zip(offspring[::2], offspring[1::2]):
+                    if random.random() < self.cxpb:
+                        self.toolbox.mate(child1, child2)
+                        del child1.fitness.values
+                        del child2.fitness.values
 
-            # Evaluate invalidated individuals
-            invalid = [ind for ind in offspring if not ind.fitness.valid]
-            for ind, fit in zip(invalid, map(self.toolbox.evaluate, invalid)):
-                ind.fitness.values = fit
+                # Mutation
+                for mutant in offspring:
+                    if random.random() < self.mutpb:
+                        self.toolbox.mutate(mutant)
+                        del mutant.fitness.values
 
-            # Generational replacement
-            pop[:] = offspring
-            hof.update(pop)
+                # Evaluate invalidated individuals
+                invalid = [ind for ind in offspring if not ind.fitness.valid]
+                if self.max_evals is not None:
+                    remaining_evals = self.max_evals - self._eval_count
+                    if len(invalid) > remaining_evals:
+                        stop_reason = 'max_evals'
+                        break
+                for ind, fit in zip(invalid, map(self.toolbox.evaluate, invalid)):
+                    ind.fitness.values = fit
 
-            # Periodic FBF improvement (optional)
-            if self.fb_improvement and self.fb_freq > 0 and gen % self.fb_freq == 0:
-                n_fb = self.apply_fb_improvement(pop)
+                # Generational replacement
+                pop[:] = offspring
                 hof.update(pop)
-                if self.verbose and n_fb:
-                    print(
-                        f"  [FBF gen {gen}] {n_fb}/{len(pop)} improved"
-                        f" | best = {hof[0].fitness.values[0]:.2f} h"
-                    )
 
-            record = stats.compile(pop)
-            log.record(gen=gen, nevals=len(invalid), **record)
-            if self.verbose:
-                print(log.stream)
+                # Periodic FBF improvement (optional)
+                if self.fb_improvement and self.fb_freq > 0 and gen % self.fb_freq == 0:
+                    n_fb = self.apply_fb_improvement(pop)
+                    hof.update(pop)
+                    if self.verbose and n_fb:
+                        print(
+                            f"  [FBF gen {gen}] {n_fb}/{len(pop)} improved"
+                            f" | best = {hof[0].fitness.values[0]:.2f} h"
+                        )
+
+                record = stats.compile(pop)
+                gen_best = hof[0].fitness.values[0]
+                if gen_best < best_ever - self.stall_tolerance:
+                    best_ever = gen_best
+                    stall = 0
+                else:
+                    stall += 1
+
+                if (
+                    self.fitness_std_tol is not None
+                    and record['std'] <= self.fitness_std_tol
+                ):
+                    std_stall += 1
+                else:
+                    std_stall = 0
+
+                stop_reason = self._stopping_reason(best_ever, stall, std_stall)
+                log.record(
+                    gen=gen,
+                    nevals=len(invalid),
+                    evals=self._eval_count,
+                    best=best_ever,
+                    stall=stall,
+                    unique_schedules=self._unique_schedule_count(),
+                    stop_reason=stop_reason or '',
+                    **record,
+                )
+                if self.verbose:
+                    print(log.stream)
+                if stop_reason is not None:
+                    break
+
+        self.stop_reason = stop_reason or 'max_generations'
+        if log:
+            log[-1]['stop_reason'] = self.stop_reason
 
         # Final FBF polish on the full population; update HoF from result
         if self.fb_improvement:
@@ -1240,6 +1420,116 @@ class RCPSPGeneticAlgorithm:
         """
         return [self._activities[i].returnName() for i in hof[0]]
 
+    def plot_convergence(
+        self,
+        log: tools.Logbook,
+        filename: Optional[str] = None,
+        show: bool = False,
+        include_avg: bool = True,
+        include_std: bool = True,
+        include_max: bool = False,
+        title: Optional[str] = None,
+        ax: Any = None,
+        dpi: int = 150,
+    ) -> Tuple[Any, Any]:
+        """
+        Plot GA convergence from the ``Logbook`` returned by ``run()``.
+
+        The plot shows per-generation population minimum fitness and the
+        cumulative best-so-far curve.  The population average and +/- one
+        standard-deviation band can be included to show convergence pressure.
+
+        Parameters
+        ----------
+        log : deap.tools.Logbook
+            Logbook returned by ``run()``.  Expected fields are ``gen``, ``min``,
+            ``avg``, ``std``, and optionally ``max``.
+        filename : str, optional
+            If supplied, save the figure to this path.
+        show : bool
+            If True, call ``matplotlib.pyplot.show()`` before returning.
+        include_avg : bool
+            Plot the population average fitness curve.
+        include_std : bool
+            Fill the average +/- one standard-deviation band.  Ignored when
+            ``include_avg`` is False.
+        include_max : bool
+            Plot the population maximum fitness curve.
+        title : str, optional
+            Custom plot title.  A default title is used when omitted.
+        ax : matplotlib.axes.Axes, optional
+            Existing axes to draw into.  If omitted, a new figure is created.
+        dpi : int
+            DPI used when saving ``filename``.
+
+        Returns
+        -------
+        (fig, ax)
+            Matplotlib figure and axes objects.
+        """
+        records = list(log)
+        if not records:
+            raise ValueError("Cannot plot an empty GA logbook.")
+
+        def _series(field: str) -> List[float]:
+            try:
+                return [float(row[field]) for row in records]
+            except KeyError as exc:
+                raise ValueError(
+                    f"GA logbook is missing required field '{field}'."
+                ) from exc
+
+        gens = _series('gen')
+        gen_min = _series('min')
+        gen_avg = _series('avg') if include_avg else []
+        gen_std = _series('std') if include_avg and include_std else []
+        best_so_far: List[float] = []
+        current_best = float('inf')
+        for value in gen_min:
+            current_best = min(current_best, value)
+            best_so_far.append(current_best)
+
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            fig, ax = plt.subplots(figsize=(8, 4.5))
+        else:
+            fig = ax.figure
+
+        ax.plot(gens, gen_min, color='tab:blue', linewidth=1.4,
+                label='Generation min')
+        ax.plot(gens, best_so_far, color='tab:green', linewidth=2.0,
+                label='Best so far')
+
+        if include_avg:
+            ax.plot(gens, gen_avg, color='tab:orange', linewidth=1.2,
+                    label='Population avg')
+            if include_std:
+                lower = [avg - std for avg, std in zip(gen_avg, gen_std)]
+                upper = [avg + std for avg, std in zip(gen_avg, gen_std)]
+                ax.fill_between(gens, lower, upper, color='tab:orange',
+                                alpha=0.15, linewidth=0,
+                                label='Avg +/- std')
+
+        if include_max:
+            gen_max = _series('max')
+            ax.plot(gens, gen_max, color='tab:red', linewidth=1.0,
+                    alpha=0.65, label='Population max')
+
+        ax.set_title(title or 'GA Convergence')
+        ax.set_xlabel('Generation')
+        ax.set_ylabel('Schedule duration (h)')
+        ax.grid(True, linestyle=':', linewidth=0.8, alpha=0.7)
+        ax.legend()
+        fig.tight_layout()
+
+        if filename:
+            fig.savefig(filename, dpi=dpi, bbox_inches='tight')
+        if show:
+            plt.show()
+
+        return fig, ax
+
     def get_convergence_summary(self, log: tools.Logbook) -> Dict:
         """
         Extract a concise convergence summary from the logbook.
@@ -1253,15 +1543,21 @@ class RCPSPGeneticAlgorithm:
         -------
         dict with keys:
             ``n_gen``, ``best_duration``, ``initial_best``, ``improvement``,
-            ``final_avg``, ``final_std``.
+            ``final_avg``, ``final_std``, ``n_evals``, ``n_unique_schedules``,
+            ``stop_reason``.
         """
         gen0 = log[0]
         final = log[-1]
+        initial_best = gen0.get('best', gen0['min'])
+        final_best = final.get('best', final['min'])
         return {
             'n_gen': len(log) - 1,
-            'best_duration': final['min'],
-            'initial_best': gen0['min'],
-            'improvement': gen0['min'] - final['min'],
+            'best_duration': final_best,
+            'initial_best': initial_best,
+            'improvement': initial_best - final_best,
             'final_avg': final['avg'],
             'final_std': final['std'],
+            'n_evals': final.get('evals', sum(row.get('nevals', 0) for row in log)),
+            'n_unique_schedules': final.get('unique_schedules', 0),
+            'stop_reason': final.get('stop_reason', 'max_generations'),
         }

--- a/src/CPM/ga.py
+++ b/src/CPM/ga.py
@@ -41,12 +41,21 @@ the ``_ordered`` keyword added in this release.  Fitness =
 
 Initial population
 ------------------
-One individual per entry in ``PRIORITY_RULES`` is seeded using
-``priority_calculation`` to build the ordering.  The schedule durations from
-both serial SGS (``calculateSerialScheduleWithResources``) and parallel SGS
+The initial population strategy is configurable:
+
+* ``'mixed'`` preserves the historical behavior: seed from ``PRIORITY_RULES``
+  first, then fill remaining population slots with random precedence-feasible
+  permutations.
+* ``'random'`` creates every individual from a random precedence-feasible
+  permutation.
+* ``'priority_rules'`` creates individuals only from deterministic named
+  priority rules and does not add random fill if fewer valid rules are available
+  than ``pop_size``.
+
+For priority-rule seeds, schedule durations from both serial SGS
+(``calculateSerialScheduleWithResources``) and parallel SGS
 (``calculateScheduleWithResources(sgs='max_use_res_ranked')``) are recorded
-for the same priority rule for benchmarking purposes only.  Remaining
-population slots are filled with random precedence-feasible permutations.
+for benchmarking purposes only.
 
 Crossover — Hartmann (1998) one-point crossover for activity lists
 ------------------------------------------------------------------
@@ -87,6 +96,7 @@ Requirements
 from __future__ import annotations
 
 import logging
+import math
 import random
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -124,9 +134,9 @@ class RCPSPGeneticAlgorithm:
         A fully initialised ``Pert`` object.  ``generateInfo()`` must have
         been called so that ``infoDict`` entries are populated.
     pop_size : int
-        Total population size.  The first ``min(len(PRIORITY_RULES), pop_size)``
-        slots are seeded from named priority rules; the rest are random
-        precedence-feasible permutations.
+        Target population size.  ``priority_rules`` initialization can produce
+        fewer individuals if fewer valid deterministic priority-rule seeds are
+        available.
     n_gen : int
         Number of GA generations.
     cxpb : float
@@ -162,6 +172,11 @@ class RCPSPGeneticAlgorithm:
         If > 0, also apply FBF every ``fb_freq`` generations during evolution
         (applied to the whole population).  ``0`` (default) disables periodic
         in-run application and limits FBF to the final polishing step.
+    initial_population_mode : str
+        Initial population source.  ``'mixed'`` seeds from priority rules then
+        fills with random chromosomes, ``'random'`` uses only random
+        precedence-feasible chromosomes, and ``'priority_rules'`` uses only
+        deterministic named priority rules.
     target_fitness : float, optional
         Stop once the Hall-of-Fame best fitness is less than or equal to this
         value.  Useful when a PSPLIB optimum or accepted target makespan is
@@ -184,6 +199,16 @@ class RCPSPGeneticAlgorithm:
     max_unique_schedules : int, optional
         Stop after observing this many unique decoded start-time schedules.
         Schedule uniqueness is tracked only when this option is supplied.
+    consensus_update_freq : int, optional
+        Generation interval for refreshing the consensus library when
+        ``mutation='consensus_reorder'``.  ``None`` uses the bounded automatic
+        rule ``min(20, max(5, n_gen // 10))``; ``0`` disables in-run refreshes.
+        Updates are ignored for other mutation operators.
+    consensus_elite_frac : float
+        Fraction of the current population to include when refreshing the
+        consensus library.  The best ``ceil(pop_size * consensus_elite_frac)``
+        valid individuals are used, along with Hall-of-Fame entries, the
+        original static references, and a few fresh random feasible orderings.
     """
 
     # DEAP creator type names (module-level singletons; guarded against
@@ -204,6 +229,7 @@ class RCPSPGeneticAlgorithm:
         'insertion_window': '_mutate_insertion_window',
         'consensus_reorder': '_mutate_consensus_reorder',
     }
+    _INITIAL_POPULATION_MODES = {'mixed', 'random', 'priority_rules'}
 
     def __init__(
         self,
@@ -220,6 +246,7 @@ class RCPSPGeneticAlgorithm:
         mutation: str = 'adjacent_swap',
         fb_improvement: bool = True,
         fb_freq: int = 0,
+        initial_population_mode: str = 'mixed',
         target_fitness: Optional[float] = None,
         max_evals: Optional[int] = None,
         stall_generations: Optional[int] = None,
@@ -227,6 +254,8 @@ class RCPSPGeneticAlgorithm:
         fitness_std_tol: Optional[float] = None,
         std_generations: int = 1,
         max_unique_schedules: Optional[int] = None,
+        consensus_update_freq: Optional[int] = None,
+        consensus_elite_frac: float = 0.2,
     ) -> None:
         if crossover not in self._CROSSOVER_METHODS:
             raise ValueError(
@@ -237,6 +266,11 @@ class RCPSPGeneticAlgorithm:
             raise ValueError(
                 f"Unknown mutation '{mutation}'. "
                 f"Choose from: {list(self._MUTATION_METHODS)}"
+            )
+        if initial_population_mode not in self._INITIAL_POPULATION_MODES:
+            raise ValueError(
+                f"Unknown initial_population_mode '{initial_population_mode}'. "
+                f"Choose from: {sorted(self._INITIAL_POPULATION_MODES)}"
             )
         if pop_size <= 0:
             raise ValueError("pop_size must be positive.")
@@ -262,6 +296,10 @@ class RCPSPGeneticAlgorithm:
             raise ValueError("std_generations must be positive.")
         if max_unique_schedules is not None and max_unique_schedules <= 0:
             raise ValueError("max_unique_schedules must be positive when supplied.")
+        if consensus_update_freq is not None and consensus_update_freq < 0:
+            raise ValueError("consensus_update_freq must be non-negative.")
+        if not 0.0 < consensus_elite_frac <= 1.0:
+            raise ValueError("consensus_elite_frac must be in (0, 1].")
 
         self.pert = pert
         self.pop_size = pop_size
@@ -275,6 +313,7 @@ class RCPSPGeneticAlgorithm:
         self.mutation = mutation
         self.fb_improvement = fb_improvement
         self.fb_freq = fb_freq
+        self.initial_population_mode = initial_population_mode
         self.target_fitness = target_fitness
         self.max_evals = max_evals
         self.stall_generations = stall_generations
@@ -282,6 +321,16 @@ class RCPSPGeneticAlgorithm:
         self.fitness_std_tol = fitness_std_tol
         self.std_generations = std_generations
         self.max_unique_schedules = max_unique_schedules
+        self.consensus_elite_frac = consensus_elite_frac
+        if mutation == 'consensus_reorder':
+            if consensus_update_freq is None:
+                self.consensus_update_freq = (
+                    min(20, max(5, n_gen // 10)) if n_gen > 0 else 0
+                )
+            else:
+                self.consensus_update_freq = consensus_update_freq
+        else:
+            self.consensus_update_freq = 0
         self.stop_reason: Optional[str] = None
 
         self._eval_count = 0
@@ -297,6 +346,7 @@ class RCPSPGeneticAlgorithm:
         self._act_to_idx: Dict[Any, int] = {
             a: i for i, a in enumerate(self._activities)
         }
+        self._static_consensus_library: List[List[int]] = []
         self._consensus_library: List[List[int]] = []
         self._consensus_position_maps: List[Dict[int, int]] = []
 
@@ -383,8 +433,8 @@ class RCPSPGeneticAlgorithm:
 
     def _build_consensus_library(self, n_random: int) -> None:
         """
-        Build a small library of precedence-feasible reference orderings used
-        by consensus-guided mutation.
+        Build the static precedence-feasible references used as the base of
+        the consensus-guided mutation library.
         """
         references: List[List[int]] = []
         seen: set[Tuple[int, ...]] = set()
@@ -411,11 +461,115 @@ class RCPSPGeneticAlgorithm:
                 references.append(chromosome)
                 seen.add(key)
 
-        self._consensus_library = references
+        self._static_consensus_library = [
+            list(chromosome) for chromosome in references
+        ]
+        self._set_consensus_library(references)
+
+    def _set_consensus_library(self, references: List[List[int]]) -> int:
+        """
+        Deduplicate and install consensus reference orderings.
+
+        Returns
+        -------
+        int
+            Number of valid unique references installed.
+        """
+        expected_genes = set(range(self._n))
+        unique: List[List[int]] = []
+        seen: set[Tuple[int, ...]] = set()
+
+        for chromosome in references:
+            if len(chromosome) != self._n or set(chromosome) != expected_genes:
+                logger.debug("Skipping invalid consensus reference.")
+                continue
+            key = tuple(chromosome)
+            if key in seen:
+                continue
+            unique.append(list(chromosome))
+            seen.add(key)
+
+        self._consensus_library = unique
         self._consensus_position_maps = [
             {gene: pos for pos, gene in enumerate(chromosome)}
-            for chromosome in references
+            for chromosome in unique
         ]
+        return len(unique)
+
+    def _consensus_updates_enabled(self) -> bool:
+        """Return True when the dynamic consensus refresh strategy is active."""
+        return (
+            self.mutation == 'consensus_reorder'
+            and self.consensus_update_freq > 0
+        )
+
+    def _should_update_consensus_library(
+        self,
+        gen: int,
+        best_improved: bool,
+    ) -> bool:
+        """
+        Refresh periodically and immediately after a new best solution appears.
+        """
+        return (
+            self._consensus_updates_enabled()
+            and (best_improved or gen % self.consensus_update_freq == 0)
+        )
+
+    def update_consensus_library(
+        self,
+        population: Optional[List[Any]] = None,
+        hof: Optional[Any] = None,
+    ) -> int:
+        """
+        Refresh the consensus library from static, elite, and random references.
+
+        The base priority-rule/random references are always retained.  Dynamic
+        updates add Hall-of-Fame individuals, the best fraction of the current
+        population, and up to four fresh random feasible chromosomes.  The
+        installed library is deduplicated before mutation samples from it.
+
+        Parameters
+        ----------
+        population : list, optional
+            Current GA population.  Only individuals with valid fitness are
+            considered, and the best ``consensus_elite_frac`` share is used.
+        hof : HallOfFame, optional
+            Current Hall of Fame; all entries are included.
+
+        Returns
+        -------
+        int
+            Number of unique references in the refreshed library.
+        """
+        references = [
+            list(chromosome) for chromosome in self._static_consensus_library
+        ]
+
+        if hof is not None:
+            references.extend(list(ind) for ind in hof)
+
+        if population:
+            valid = [
+                ind for ind in population
+                if hasattr(ind, 'fitness') and ind.fitness.valid
+            ]
+            valid.sort(key=lambda ind: ind.fitness.values[0])
+            top_count = max(1, math.ceil(len(valid) * self.consensus_elite_frac))
+            references.extend(list(ind) for ind in valid[:top_count])
+
+        # Keep a small amount of fresh diversity in every refresh without
+        # letting random references dominate the elite signal.
+        for _ in range(min(self.n_random, 4)):
+            try:
+                references.append(self._rule_to_chromosome('random'))
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(
+                    "Skipping random reference during consensus refresh: %s",
+                    exc,
+                )
+
+        return self._set_consensus_library(references)
 
     # ---------------------------------------------------------------------- #
     # Forward-Backward-Forward (FBF) improvement                               #
@@ -542,44 +696,39 @@ class RCPSPGeneticAlgorithm:
     # Initial population                                                       #
     # ---------------------------------------------------------------------- #
 
-    def generate_initial_population(self) -> List[Any]:
+    def _priority_seed_rules(
+        self,
+        initial_population_mode: Optional[str] = None,
+    ) -> List[str]:
         """
-        Build the initial population.
+        Return the priority rules used by the selected initialization mode.
 
-        For each rule in ``PRIORITY_RULES`` (up to ``pop_size``):
-
-        1. Derive a precedence-feasible activity list chromosome via
-           ``_rule_to_chromosome(rule)``.
-        2. Record the schedule duration produced by the same priority rule
-           under *both* SGS variants for benchmarking:
-
-           - Serial SGS: ``calculateSerialScheduleWithResources(priority_rule=rule)``
-           - Parallel SGS: ``calculateScheduleWithResources(sgs='max_use_res_ranked',
-             priority_rule=rule)``
-
-        Remaining slots are filled with random precedence-feasible permutations
-        obtained by calling ``_rule_to_chromosome('random')``, which applies
-        ``priority_calculation`` with ``priority_rule='random'`` and thereby
-        uses ``reorder_by_dependencies`` to enforce topological feasibility.
-
-        ``pert.priorities`` is cleared to ``None`` before each named-rule SGS
-        call so that any previously injected external priorities do not
-        interfere.
-
-        Returns
-        -------
-        list of IndividualRCPSP
+        ``mixed`` preserves the historical behavior and includes the ``random``
+        rule entry from ``PRIORITY_RULES``.  ``priority_rules`` excludes that
+        entry so the mode is deterministic apart from GA tie-breaking and later
+        genetic operators.
         """
-        population: List[Any] = []
-        seed_info: Dict[str, Dict[str, float]] = {}
+        mode = initial_population_mode or self.initial_population_mode
+        if mode == 'priority_rules':
+            return [rule for rule in PRIORITY_RULES if rule != 'random']
+        return PRIORITY_RULES
 
-        for rule in PRIORITY_RULES:
+    def _append_priority_rule_seeds(
+        self,
+        population: List[Any],
+        seed_info: Dict[str, Dict[str, float]],
+        initial_population_mode: Optional[str] = None,
+    ) -> int:
+        """Append priority-rule chromosomes to the initial population."""
+        n_seeded = 0
+        for rule in self._priority_seed_rules(initial_population_mode):
             if len(population) >= self.pop_size:
                 break
             try:
                 # --- chromosome from rule ordering ---
                 chromosome = self._rule_to_chromosome(rule)
                 population.append(self._Ind(chromosome))
+                n_seeded += 1
 
                 # --- serial SGS duration (informational) ---
                 self.pert.priorities = None
@@ -602,8 +751,10 @@ class RCPSPGeneticAlgorithm:
                 logger.warning(
                     "Skipping rule '%s' during population seeding: %s", rule, exc
                 )
+        return n_seeded
 
-        # --- fill remaining slots with random precedence-feasible permutations ---
+    def _fill_random_population(self, population: List[Any]) -> int:
+        """Fill population slots with random precedence-feasible chromosomes."""
         n_random = 0
         random_failures = 0
         max_random_failures = max(10, self.pop_size * 2)
@@ -624,34 +775,129 @@ class RCPSPGeneticAlgorithm:
                 continue
             population.append(self._Ind(chromosome))
             n_random += 1
+        return n_random
+
+    def generate_initial_population(
+        self,
+        initial_population_mode: Optional[str] = None,
+    ) -> List[Any]:
+        """
+        Build the initial population according to ``initial_population_mode``.
+
+        Modes
+        -----
+        mixed
+            Historical behavior.  Seed from ``PRIORITY_RULES`` first, then
+            fill remaining slots with random precedence-feasible chromosomes.
+        random
+            Create every individual with ``priority_rule='random'``.
+        priority_rules
+            Seed only from deterministic named priority rules.  No random fill
+            is added, so the returned population can be smaller than
+            ``pop_size`` when fewer valid priority-rule seeds are available.
+
+        For priority-rule seeds, the function records the schedule duration
+        produced by the same priority rule under *both* SGS variants:
+
+        - Serial SGS: ``calculateSerialScheduleWithResources(priority_rule=rule)``
+        - Parallel SGS: ``calculateScheduleWithResources(sgs='max_use_res_ranked',
+          priority_rule=rule)``
+
+        ``pert.priorities`` is cleared to ``None`` before each named-rule SGS
+        call so that any previously injected external priorities do not
+        interfere.
+
+        Parameters
+        ----------
+        initial_population_mode : str, optional
+            Override ``self.initial_population_mode`` for this call.
+
+        Returns
+        -------
+        list of IndividualRCPSP
+        """
+        mode = initial_population_mode or self.initial_population_mode
+        if mode not in self._INITIAL_POPULATION_MODES:
+            raise ValueError(
+                f"Unknown initial_population_mode '{mode}'. "
+                f"Choose from: {sorted(self._INITIAL_POPULATION_MODES)}"
+            )
+
+        population: List[Any] = []
+        seed_info: Dict[str, Dict[str, float]] = {}
+        n_rule_seeded = 0
+        n_random = 0
+
+        if mode in {'mixed', 'priority_rules'}:
+            n_rule_seeded = self._append_priority_rule_seeds(
+                population,
+                seed_info,
+                mode,
+            )
+
+        if mode in {'mixed', 'random'}:
+            n_random = self._fill_random_population(population)
 
         if not population:
             raise RuntimeError(
                 "Failed to generate any valid individuals for the initial population."
             )
 
-        if seed_info and self.verbose:
-            all_dur = [v for info in seed_info.values() for v in info.values()]
-            print(
-                f"\nInitial population: {len(seed_info)} rule-seeded + "
-                f"{n_random} random  |  best seeded = {min(all_dur):.2f} h\n"
-            )
-            print(f"  {'Rule':<22} {'Serial (h)':>12} {'Parallel (h)':>14}")
-            print("  " + "-" * 50)
-            for r, info in seed_info.items():
-                print(
-                    f"  {r:<22} {info['serial']:>12.2f} {info['parallel']:>14.2f}"
-                )
-            print()
-        elif seed_info:
-            all_dur = [v for info in seed_info.values() for v in info.values()]
+        if (
+            mode == 'priority_rules'
+            and len(population) < self.pop_size
+        ):
             logger.info(
-                "Initial population: %d rule-seeded + %d random | "
-                "best seeded duration = %.2f h",
-                len(seed_info),
-                n_random,
-                min(all_dur),
+                "Initial population mode 'priority_rules' produced %d/%d "
+                "requested individuals because no random fill is used.",
+                len(population),
+                self.pop_size,
             )
+
+        best_seeded = None
+        if seed_info:
+            all_dur = [v for info in seed_info.values() for v in info.values()]
+            best_seeded = min(all_dur)
+
+        if self.verbose:
+            msg = (
+                f"\nInitial population ({mode}): "
+                f"{n_rule_seeded} rule-seeded + {n_random} random"
+                f"  |  total = {len(population)}"
+            )
+            if best_seeded is not None:
+                msg += f"  |  best seeded = {best_seeded:.2f} h"
+            print(f"{msg}\n")
+            if seed_info:
+                print(f"  {'Rule':<22} {'Serial (h)':>12} {'Parallel (h)':>14}")
+                print("  " + "-" * 50)
+                for r, info in seed_info.items():
+                    print(
+                        f"  {r:<22} {info['serial']:>12.2f} "
+                        f"{info['parallel']:>14.2f}"
+                    )
+                print()
+        else:
+            msg = (
+                "Initial population (%s): %d rule-seeded + %d random | total = %d"
+            )
+            if best_seeded is not None:
+                logger.info(
+                    msg + " | best seeded duration = %.2f h",
+                    mode,
+                    n_rule_seeded,
+                    n_random,
+                    len(population),
+                    best_seeded,
+                )
+            else:
+                logger.info(
+                    msg,
+                    mode,
+                    n_rule_seeded,
+                    n_random,
+                    len(population),
+                )
 
         return population
 
@@ -1199,15 +1445,18 @@ class RCPSPGeneticAlgorithm:
 
         Workflow
         --------
-        1. Generate initial population (priority-rule seeding + random fill).
+        1. Generate initial population using ``initial_population_mode``.
         2. Evaluate fitness for every individual in generation 0.
         3. For each of ``n_gen`` generations:
            a. Tournament selection.
            b. Pairwise crossover with probability ``cxpb``.
            c. Apply the configured mutation operator with probability ``mutpb``.
            d. Re-evaluate invalidated offspring.
-           d. Generational replacement.
-           e. Update Hall of Fame and statistics logbook.
+           e. Generational replacement.
+           f. Update Hall of Fame.
+           g. Refresh the consensus library when ``consensus_reorder`` is active
+              and the configured generation interval or improvement trigger fires.
+           h. Update statistics logbook.
 
         Returns
         -------
@@ -1244,6 +1493,8 @@ class RCPSPGeneticAlgorithm:
             "unique_schedules", "stop_reason",
         ] + stats.fields
         hof.update(pop)
+        if self._consensus_updates_enabled():
+            self.update_consensus_library(pop, hof)
         record = stats.compile(pop)
         best_ever = hof[0].fitness.values[0]
         stall = 0
@@ -1318,11 +1569,25 @@ class RCPSPGeneticAlgorithm:
 
                 record = stats.compile(pop)
                 gen_best = hof[0].fitness.values[0]
-                if gen_best < best_ever - self.stall_tolerance:
+                best_improved = gen_best < best_ever - self.stall_tolerance
+                if best_improved:
                     best_ever = gen_best
                     stall = 0
                 else:
                     stall += 1
+
+                if self._should_update_consensus_library(gen, best_improved):
+                    n_refs = self.update_consensus_library(pop, hof)
+                    if self.verbose:
+                        reason = (
+                            "new best"
+                            if best_improved
+                            else f"freq={self.consensus_update_freq}"
+                        )
+                        print(
+                            f"  [Consensus gen {gen}] refreshed "
+                            f"{n_refs} references ({reason})"
+                        )
 
                 if (
                     self.fitness_std_tol is not None
@@ -1370,10 +1635,10 @@ class RCPSPGeneticAlgorithm:
             )
 
         logger.info(
-            "GA finished | best = %.2f h | generations = %d | pop_size = %d",
+            "GA finished | best = %.2f h | generations = %d | population = %d",
             hof[0].fitness.values[0],
             self.n_gen,
-            self.pop_size,
+            len(pop),
         )
         return hof, log
 

--- a/src/CPM/ga.py
+++ b/src/CPM/ga.py
@@ -199,6 +199,18 @@ class RCPSPGeneticAlgorithm:
                 f"Unknown mutation '{mutation}'. "
                 f"Choose from: {list(self._MUTATION_METHODS)}"
             )
+        if pop_size <= 0:
+            raise ValueError("pop_size must be positive.")
+        if n_gen < 0:
+            raise ValueError("n_gen must be non-negative.")
+        if not 0.0 <= cxpb <= 1.0:
+            raise ValueError("cxpb must be in [0, 1].")
+        if not 0.0 <= mutpb <= 1.0:
+            raise ValueError("mutpb must be in [0, 1].")
+        if n_random < 0:
+            raise ValueError("n_random must be non-negative.")
+        if hof_size <= 0:
+            raise ValueError("hof_size must be positive.")
 
         self.pert = pert
         self.pop_size = pop_size
@@ -407,10 +419,30 @@ class RCPSPGeneticAlgorithm:
 
         # --- fill remaining slots with random precedence-feasible permutations ---
         n_random = 0
+        random_failures = 0
+        max_random_failures = max(10, self.pop_size * 2)
         while len(population) < self.pop_size:
-            chromosome = self._rule_to_chromosome('random')
+            try:
+                chromosome = self._rule_to_chromosome('random')
+            except Exception as exc:  # noqa: BLE001
+                random_failures += 1
+                logger.warning(
+                    "Random chromosome generation failed during population "
+                    "seeding (%d/%d): %s",
+                    random_failures,
+                    max_random_failures,
+                    exc,
+                )
+                if random_failures >= max_random_failures:
+                    break
+                continue
             population.append(self._Ind(chromosome))
             n_random += 1
+
+        if not population:
+            raise RuntimeError(
+                "Failed to generate any valid individuals for the initial population."
+            )
 
         if seed_info and self.verbose:
             all_dur = [v for info in seed_info.values() for v in info.values()]
@@ -518,16 +550,20 @@ class RCPSPGeneticAlgorithm:
 
         q = random.randint(1, n - 1)
 
+        # Save originals so Child 2 reads the unmodified first parent.
+        orig1 = list(ind1)
+        orig2 = list(ind2)
+
         # --- Child 1: prefix from ind1 (mother), suffix from ind2 (father) ---
-        prefix1 = list(ind1[:q])
+        prefix1 = list(orig1[:q])
         taken1 = set(prefix1)
-        suffix1 = [gene for gene in ind2 if gene not in taken1]
+        suffix1 = [gene for gene in orig2 if gene not in taken1]
         ind1[:] = prefix1 + suffix1
 
         # --- Child 2: prefix from ind2 (mother), suffix from ind1 (father) ---
-        prefix2 = list(ind2[:q])
+        prefix2 = list(orig2[:q])
         taken2 = set(prefix2)
-        suffix2 = [gene for gene in ind1 if gene not in taken2]
+        suffix2 = [gene for gene in orig1 if gene not in taken2]
         ind2[:] = prefix2 + suffix2
 
         return ind1, ind2
@@ -935,6 +971,8 @@ class RCPSPGeneticAlgorithm:
         """
         # ── Generation 0 ─────────────────────────────────────────────────────
         pop = self.generate_initial_population()
+        if not pop:
+            raise RuntimeError("Initial population is empty; GA cannot run.")
 
         fitnesses = list(map(self.toolbox.evaluate, pop))
         for ind, fit in zip(pop, fitnesses):

--- a/src/CPM/ga_operator_test.py
+++ b/src/CPM/ga_operator_test.py
@@ -1,0 +1,532 @@
+"""
+ga_operator_test.py - Compare GA crossover/mutation operator combinations.
+
+Run this script with one RCPSP JSON input.  It executes the standard GA once for
+each selected crossover/mutation pair, plots all convergence curves in one figure,
+and prints a comparison table sorted by final GA duration.
+
+Usage from the repo root:
+    python -m src.CPM.ga_operator_test src/CPM/j301_1.json
+
+Usage from the src/CPM directory:
+    python ga_operator_test.py j301_1.json
+
+Examples:
+    python -m src.CPM.ga_operator_test src/CPM/j301_1.json --n-gen 100
+    python -m src.CPM.ga_operator_test j301_1.json --crossovers two_point --mutations swap,adjacent_swap
+    python -m src.CPM.ga_operator_test j301_1.json --max-evals 5000 --no-fb-improvement
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# Ensure repo root is on the path before project imports.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src import Pert  # noqa: E402
+from src.CPM.ga import RCPSPGeneticAlgorithm, PRIORITY_RULES  # noqa: E402
+
+
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(levelname)s: %(message)s",
+    force=True,
+)
+logger = logging.getLogger(__name__)
+
+CPM_DIR = Path(__file__).parent
+SCHEMA = CPM_DIR / "outage_schema.json"
+BEST_RESULTS_PATH = CPM_DIR / "benchmarks" / "best_results.json"
+DEFAULT_OUTPUT_DIR = CPM_DIR / "results" / "ga_operator_test"
+
+
+def _available_crossovers() -> list[str]:
+    return list(RCPSPGeneticAlgorithm._CROSSOVER_METHODS)
+
+
+def _available_mutations() -> list[str]:
+    return list(RCPSPGeneticAlgorithm._MUTATION_METHODS)
+
+
+def _parse_name_list(raw: str | list[str], choices: list[str], label: str) -> list[str]:
+    """Parse comma-separated or whitespace-separated operator names."""
+    raw_values = [raw] if isinstance(raw, str) else raw
+    if raw_values == ["all"]:
+        return choices
+    names: list[str] = []
+    for value in raw_values:
+        for chunk in value.split(","):
+            names.extend(part.strip() for part in chunk.split() if part.strip())
+    unknown = [name for name in names if name not in choices]
+    if unknown:
+        raise argparse.ArgumentTypeError(
+            f"Unknown {label}: {unknown}. Choose from {choices} or 'all'."
+        )
+    deduped: list[str] = []
+    for name in names:
+        if name not in deduped:
+            deduped.append(name)
+    if not deduped:
+        raise argparse.ArgumentTypeError(f"At least one {label} is required.")
+    return deduped
+
+
+def _resolve_json_path(path: str | Path) -> Path:
+    """Resolve JSON input from cwd, absolute path, or src/CPM-relative path."""
+    candidate = Path(path).expanduser()
+    if candidate.exists():
+        return candidate.resolve()
+    cpm_candidate = CPM_DIR / candidate
+    if cpm_candidate.exists():
+        return cpm_candidate.resolve()
+    raise FileNotFoundError(f"Could not find JSON input: {path}")
+
+
+def _safe_float(value: float | None) -> str:
+    if value is None or math.isnan(value):
+        return "nan"
+    return f"{value:.2f}"
+
+
+def parse_args() -> argparse.Namespace:
+    crossovers = _available_crossovers()
+    mutations = _available_mutations()
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run all selected GA crossover/mutation combinations for one RCPSP "
+            "JSON input and compare final results."
+        )
+    )
+    parser.add_argument(
+        "json_input",
+        help="RCPSP JSON input path. Relative paths are checked against cwd and src/CPM.",
+    )
+    parser.add_argument(
+        "--crossovers",
+        nargs="+",
+        default=["all"],
+        help=f"Selected crossovers, or 'all'. Choices: {crossovers}.",
+    )
+    parser.add_argument(
+        "--mutations",
+        nargs="+",
+        default=["all"],
+        help=f"Selected mutations, or 'all'. Choices: {mutations}.",
+    )
+    parser.add_argument("--pop-size", type=int, default=50)
+    parser.add_argument("--n-gen", type=int, default=100)
+    parser.add_argument("--cxpb", type=float, default=0.9)
+    parser.add_argument("--mutpb", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--n-random", type=int, default=8)
+    parser.add_argument("--hof-size", type=int, default=5)
+    parser.add_argument(
+        "--initial-population-mode",
+        choices=["mixed", "random", "priority_rules"],
+        default="mixed",
+        help=(
+            "Initial GA population source: priority-rule seeds plus random fill "
+            "(mixed), all random, or deterministic priority rules only."
+        ),
+    )
+    parser.add_argument(
+        "--consensus-update-freq",
+        type=int,
+        help=(
+            "Generation interval for refreshing the consensus library when "
+            "using consensus_reorder mutation. Omit for auto; use 0 to disable."
+        ),
+    )
+    parser.add_argument(
+        "--consensus-elite-frac",
+        type=float,
+        default=0.2,
+        help="Fraction of the current population used in consensus refreshes.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Disable verbose GA output for each combination.",
+    )
+    parser.add_argument(
+        "--no-fb-improvement",
+        action="store_true",
+        help="Disable final Forward-Backward-Forward improvement.",
+    )
+    parser.add_argument("--fb-freq", type=int, default=0)
+
+    stopping = parser.add_argument_group("stopping criteria")
+    stopping.add_argument("--target-fitness", type=float)
+    stopping.add_argument(
+        "--target-best-known",
+        action="store_true",
+        help="Use best-known result for the JSON filename as target_fitness.",
+    )
+    stopping.add_argument("--max-evals", type=int)
+    stopping.add_argument("--stall-generations", type=int)
+    stopping.add_argument("--stall-tolerance", type=float, default=1e-9)
+    stopping.add_argument("--fitness-std-tol", type=float)
+    stopping.add_argument("--std-generations", type=int, default=1)
+    stopping.add_argument("--max-unique-schedules", type=int)
+
+    output = parser.add_argument_group("output")
+    output.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory for generated comparison CSV and plot.",
+    )
+    output.add_argument(
+        "--plot-file",
+        type=Path,
+        help="Path for combined convergence plot. Defaults under --output-dir.",
+    )
+    output.add_argument(
+        "--csv-file",
+        type=Path,
+        help="Path for comparison CSV. Defaults under --output-dir.",
+    )
+    output.add_argument(
+        "--no-plot",
+        action="store_true",
+        help="Skip convergence plot generation.",
+    )
+    output.add_argument(
+        "--show",
+        action="store_true",
+        help="Show the convergence plot interactively after saving.",
+    )
+
+    args = parser.parse_args()
+    if args.target_best_known and args.target_fitness is not None:
+        parser.error("--target-best-known and --target-fitness are mutually exclusive.")
+
+    try:
+        args.crossovers = _parse_name_list(args.crossovers, crossovers, "crossover")
+        args.mutations = _parse_name_list(args.mutations, mutations, "mutation")
+        args.json_path = _resolve_json_path(args.json_input)
+    except (argparse.ArgumentTypeError, FileNotFoundError) as exc:
+        parser.error(str(exc))
+    return args
+
+
+def load_best_known_results() -> dict[str, float]:
+    if not BEST_RESULTS_PATH.exists():
+        return {}
+    with BEST_RESULTS_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_best_known_result(best_results: dict[str, float], json_path: Path) -> float | None:
+    return best_results.get(f"{json_path.stem}.sm")
+
+
+def load_pert(json_path: Path) -> Any:
+    pert = Pert.from_json_file(str(json_path), schema_path=str(SCHEMA))
+    pert.generateInfo()
+    return pert
+
+
+def compute_priority_baseline(json_path: Path) -> dict[str, Any]:
+    """Compute CPM and priority-rule baselines once for the input instance."""
+    pert = load_pert(json_path)
+    cpm_duration = pert.getProjectDuration()
+    n_activities = len(pert.infoDict)
+    serial_durations: dict[str, float] = {}
+    parallel_durations: dict[str, float] = {}
+
+    for rule in PRIORITY_RULES:
+        try:
+            pert.priorities = None
+            s_out = pert.calculateSerialScheduleWithResources(priority_rule=rule)
+            serial_durations[rule] = s_out["scheduled_duration"] - 2
+
+            pert.priorities = None
+            p_out = pert.calculateScheduleWithResources(
+                sgs="max_use_res_ranked",
+                priority_rule=rule,
+            )
+            parallel_durations[rule] = p_out["scheduled_duration"] - 2
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Rule '%s' skipped in baseline: %s", rule, exc)
+
+    best_serial = min(serial_durations.values()) if serial_durations else float("inf")
+    best_parallel = min(parallel_durations.values()) if parallel_durations else float("inf")
+    return {
+        "n_activities": n_activities,
+        "cpm_duration": cpm_duration,
+        "best_serial": best_serial,
+        "best_parallel": best_parallel,
+        "best_rule_overall": min(best_serial, best_parallel),
+    }
+
+
+def _best_series(log: Any) -> tuple[list[float], list[float]]:
+    """Return generation and best-so-far series from a DEAP logbook."""
+    records = list(log)
+    gens = [float(row["gen"]) for row in records]
+    if records and "best" in records[0]:
+        best = [float(row["best"]) for row in records]
+    else:
+        best = []
+        current = float("inf")
+        for row in records:
+            current = min(current, float(row["min"]))
+            best.append(current)
+    return gens, best
+
+
+def run_operator_case(
+    json_path: Path,
+    crossover: str,
+    mutation: str,
+    args: argparse.Namespace,
+    target_fitness: float | None,
+    best_rule_overall: float,
+    best_known: float | None,
+) -> dict[str, Any]:
+    """Run one crossover/mutation combination on a fresh Pert instance."""
+    print(f"Running GA: crossover={crossover}, mutation={mutation}")
+    pert = load_pert(json_path)
+    ga = RCPSPGeneticAlgorithm(
+        pert,
+        pop_size=args.pop_size,
+        n_gen=args.n_gen,
+        cxpb=args.cxpb,
+        mutpb=args.mutpb,
+        seed=args.seed,
+        n_random=args.n_random,
+        hof_size=args.hof_size,
+        verbose=not args.quiet,
+        crossover=crossover,
+        mutation=mutation,
+        fb_improvement=not args.no_fb_improvement,
+        fb_freq=args.fb_freq,
+        initial_population_mode=args.initial_population_mode,
+        target_fitness=target_fitness,
+        max_evals=args.max_evals,
+        stall_generations=args.stall_generations,
+        stall_tolerance=args.stall_tolerance,
+        fitness_std_tol=args.fitness_std_tol,
+        std_generations=args.std_generations,
+        max_unique_schedules=args.max_unique_schedules,
+        consensus_update_freq=args.consensus_update_freq,
+        consensus_elite_frac=args.consensus_elite_frac,
+    )
+    hof, log = ga.run()
+    best_result = ga.get_best_schedule(hof)
+    best_ga = best_result["scheduled_duration"] - 2
+    summary = ga.get_convergence_summary(log)
+    gens, best_curve = _best_series(log)
+
+    return {
+        "crossover": crossover,
+        "mutation": mutation,
+        "label": f"{crossover}/{mutation}",
+        "best_ga": best_ga,
+        "logged_best": summary["best_duration"],
+        "initial_best": summary["initial_best"],
+        "improvement_gen0": summary["improvement"],
+        "improvement_vs_seed": best_rule_overall - best_ga,
+        "best_known": best_known,
+        "gap_to_best_known": (
+            best_ga - best_known if best_known is not None else float("nan")
+        ),
+        "final_avg": summary["final_avg"],
+        "final_std": summary["final_std"],
+        "n_gen_executed": summary["n_gen"],
+        "n_evals": summary["n_evals"],
+        "n_unique_schedules": summary["n_unique_schedules"],
+        "stop_reason": summary["stop_reason"],
+        "gens": gens,
+        "best_curve": best_curve,
+    }
+
+
+def plot_combined_convergence(
+    results: list[dict[str, Any]],
+    filename: Path,
+    title: str,
+    show: bool = False,
+) -> None:
+    """Plot best-so-far convergence curves for all operator combinations."""
+    import matplotlib
+
+    matplotlib.use("Agg", force=not show)
+    import matplotlib.pyplot as plt
+
+    filename.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(11, 6.5))
+    for result in results:
+        ax.plot(
+            result["gens"],
+            result["best_curve"],
+            linewidth=1.6,
+            label=result["label"],
+        )
+        if result["gens"] and result["best_curve"]:
+            ax.scatter(
+                result["gens"][-1],
+                result["best_curve"][-1],
+                s=18,
+                zorder=3,
+            )
+
+    ax.set_title(title)
+    ax.set_xlabel("Generation")
+    ax.set_ylabel("Best-so-far duration (h)")
+    ax.grid(True, linestyle=":", linewidth=0.8, alpha=0.7)
+    ax.legend(fontsize=8, ncol=2)
+    fig.tight_layout()
+    fig.savefig(filename, dpi=150, bbox_inches="tight")
+    if show:
+        plt.show()
+    plt.close(fig)
+
+
+def write_csv(results: list[dict[str, Any]], filename: Path) -> None:
+    filename.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "rank",
+        "crossover",
+        "mutation",
+        "best_ga",
+        "gap_to_best_known",
+        "improvement_vs_seed",
+        "initial_best",
+        "logged_best",
+        "improvement_gen0",
+        "final_avg",
+        "final_std",
+        "n_gen_executed",
+        "n_evals",
+        "n_unique_schedules",
+        "stop_reason",
+    ]
+    with filename.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for rank, result in enumerate(results, start=1):
+            row = {field: result.get(field) for field in fields}
+            row["rank"] = rank
+            writer.writerow(row)
+
+
+def print_comparison(
+    results: list[dict[str, Any]],
+    baseline: dict[str, Any],
+    best_known: float | None,
+) -> None:
+    print()
+    print("=" * 118)
+    print("GA OPERATOR COMPARISON")
+    print("=" * 118)
+    print(f"Activities        : {baseline['n_activities']}")
+    print(f"CPM duration      : {baseline['cpm_duration']:.2f} h")
+    print(f"Best serial seed  : {baseline['best_serial']:.2f} h")
+    print(f"Best parallel seed: {baseline['best_parallel']:.2f} h")
+    print(f"Best known        : {_safe_float(best_known)} h")
+    print("-" * 118)
+    print(
+        f"{'Rank':>4} {'Crossover':<14} {'Mutation':<18} "
+        f"{'Best':>8} {'BK Gap':>8} {'Seed Gap':>9} "
+        f"{'Gen':>5} {'Evals':>8} {'Avg/Std':>17} {'Stop':>20}"
+    )
+    print("-" * 118)
+    for rank, r in enumerate(results, start=1):
+        avg_std = f"{r['final_avg']:.2f}/{r['final_std']:.2f}"
+        print(
+            f"{rank:>4} {r['crossover']:<14} {r['mutation']:<18} "
+            f"{r['best_ga']:>8.2f} {_safe_float(r['gap_to_best_known']):>8} "
+            f"{r['improvement_vs_seed']:>9.2f} {r['n_gen_executed']:>5} "
+            f"{r['n_evals']:>8} {avg_std:>17} {r['stop_reason']:>20}"
+        )
+    print("-" * 118)
+    best = results[0]
+    print(
+        "Best combination: "
+        f"{best['crossover']} crossover + {best['mutation']} mutation "
+        f"with final duration {best['best_ga']:.2f} h"
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    best_results = load_best_known_results()
+    best_known = get_best_known_result(best_results, args.json_path)
+    target_fitness = best_known if args.target_best_known else args.target_fitness
+    baseline = compute_priority_baseline(args.json_path)
+
+    print("=" * 78)
+    print(f"Input: {args.json_path}")
+    print(f"Crossovers: {', '.join(args.crossovers)}")
+    print(f"Mutations : {', '.join(args.mutations)}")
+    print(f"Runs      : {len(args.crossovers) * len(args.mutations)}")
+    print("=" * 78)
+
+    results: list[dict[str, Any]] = []
+    for crossover in args.crossovers:
+        for mutation in args.mutations:
+            result = run_operator_case(
+                args.json_path,
+                crossover,
+                mutation,
+                args,
+                target_fitness,
+                baseline["best_rule_overall"],
+                best_known,
+            )
+            results.append(result)
+
+    results.sort(
+        key=lambda r: (
+            r["best_ga"],
+            r["n_evals"],
+            r["crossover"],
+            r["mutation"],
+        )
+    )
+
+    stem = args.json_path.stem
+    plot_file = args.plot_file or (
+        args.output_dir / f"{stem}_operator_convergence_seed{args.seed}.png"
+    )
+    csv_file = args.csv_file or (
+        args.output_dir / f"{stem}_operator_comparison_seed{args.seed}.csv"
+    )
+
+    if not args.no_plot:
+        plot_combined_convergence(
+            results,
+            plot_file,
+            title=f"GA Operator Convergence - {stem}",
+            show=args.show,
+        )
+        print(f"Combined convergence plot: {plot_file}")
+
+    write_csv(results, csv_file)
+    print(f"Comparison CSV: {csv_file}")
+
+    print_comparison(results, baseline, best_known)
+    if not args.no_fb_improvement:
+        print()
+        print(
+            "Note: convergence curves use the GA logbook. Final FBF polishing can "
+            "improve the table's final duration after the last logged generation."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CPM/ga_priority_rule_vs_random.py
+++ b/src/CPM/ga_priority_rule_vs_random.py
@@ -1,0 +1,651 @@
+"""
+ga_priority_rule_vs_random.py - Compare mixed vs random GA initialization.
+
+This script fixes crossover to ``uniform_order`` and runs every selected
+mutation operator twice:
+
+* ``initial_population_mode='mixed'``: priority-rule seeds plus random fill.
+* ``initial_population_mode='random'``: all random precedence-feasible seeds.
+
+The output is intended to isolate how much the priority-rule seeded initial
+population helps relative to fully random initialization.
+
+Usage from the repo root:
+    python -m src.CPM.ga_priority_rule_vs_random src/CPM/j1201_1.json
+
+Usage from the src/CPM directory:
+    python ga_priority_rule_vs_random.py j1201_1.json
+
+Examples:
+    python -m src.CPM.ga_priority_rule_vs_random src/CPM/j1201_1.json --n-gen 100
+    python -m src.CPM.ga_priority_rule_vs_random j1201_1.json --mutations all
+    python -m src.CPM.ga_priority_rule_vs_random j1201_1.json --no-fb-improvement
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# Ensure repo root is on the path before project imports.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src import Pert  # noqa: E402
+from src.CPM.ga import RCPSPGeneticAlgorithm, PRIORITY_RULES  # noqa: E402
+
+
+logging.basicConfig(
+    level=logging.WARNING,
+    format="%(levelname)s: %(message)s",
+    force=True,
+)
+logger = logging.getLogger(__name__)
+
+CPM_DIR = Path(__file__).parent
+SCHEMA = CPM_DIR / "outage_schema.json"
+BEST_RESULTS_PATH = CPM_DIR / "benchmarks" / "best_results.json"
+DEFAULT_OUTPUT_DIR = CPM_DIR / "results" / "ga_priority_rule_vs_random"
+FIXED_CROSSOVER = "uniform_order"
+DEFAULT_INITIAL_POPULATION_MODES = ["mixed", "random"]
+
+
+def _available_mutations() -> list[str]:
+    return list(RCPSPGeneticAlgorithm._MUTATION_METHODS)
+
+
+def _parse_name_list(raw: str | list[str], choices: list[str], label: str) -> list[str]:
+    """Parse comma-separated or whitespace-separated names."""
+    raw_values = [raw] if isinstance(raw, str) else raw
+    if raw_values == ["all"]:
+        return choices
+    names: list[str] = []
+    for value in raw_values:
+        for chunk in value.split(","):
+            names.extend(part.strip() for part in chunk.split() if part.strip())
+    unknown = [name for name in names if name not in choices]
+    if unknown:
+        raise argparse.ArgumentTypeError(
+            f"Unknown {label}: {unknown}. Choose from {choices} or 'all'."
+        )
+    deduped: list[str] = []
+    for name in names:
+        if name not in deduped:
+            deduped.append(name)
+    if not deduped:
+        raise argparse.ArgumentTypeError(f"At least one {label} is required.")
+    return deduped
+
+
+def _resolve_json_path(path: str | Path) -> Path:
+    """Resolve JSON input from cwd, absolute path, or src/CPM-relative path."""
+    candidate = Path(path).expanduser()
+    if candidate.exists():
+        return candidate.resolve()
+    cpm_candidate = CPM_DIR / candidate
+    if cpm_candidate.exists():
+        return cpm_candidate.resolve()
+    raise FileNotFoundError(f"Could not find JSON input: {path}")
+
+
+def _safe_float(value: float | None) -> str:
+    if value is None or math.isnan(value):
+        return "nan"
+    return f"{value:.2f}"
+
+
+def parse_args() -> argparse.Namespace:
+    mutations = _available_mutations()
+    initial_modes = DEFAULT_INITIAL_POPULATION_MODES
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare mixed priority-rule seeding vs fully random initialization "
+            f"with fixed {FIXED_CROSSOVER!r} crossover."
+        )
+    )
+    parser.add_argument(
+        "json_input",
+        help="RCPSP JSON input path. Relative paths are checked against cwd and src/CPM.",
+    )
+    parser.add_argument(
+        "--mutations",
+        nargs="+",
+        default=["all"],
+        help=f"Selected mutations, or 'all'. Choices: {mutations}.",
+    )
+    parser.add_argument(
+        "--initial-population-modes",
+        nargs="+",
+        default=initial_modes,
+        help=(
+            "Initialization modes to compare. Default: mixed random. "
+            f"Choices: {initial_modes}."
+        ),
+    )
+    parser.add_argument("--pop-size", type=int, default=50)
+    parser.add_argument("--n-gen", type=int, default=100)
+    parser.add_argument("--cxpb", type=float, default=0.9)
+    parser.add_argument("--mutpb", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--n-random", type=int, default=8)
+    parser.add_argument("--hof-size", type=int, default=5)
+    parser.add_argument(
+        "--consensus-update-freq",
+        type=int,
+        help=(
+            "Generation interval for refreshing the consensus library when "
+            "using consensus_reorder mutation. Omit for auto; use 0 to disable."
+        ),
+    )
+    parser.add_argument(
+        "--consensus-elite-frac",
+        type=float,
+        default=0.2,
+        help="Fraction of the current population used in consensus refreshes.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Disable verbose GA output for each run.",
+    )
+    parser.add_argument(
+        "--no-fb-improvement",
+        action="store_true",
+        help="Disable final Forward-Backward-Forward improvement.",
+    )
+    parser.add_argument("--fb-freq", type=int, default=0)
+
+    stopping = parser.add_argument_group("stopping criteria")
+    stopping.add_argument("--target-fitness", type=float)
+    stopping.add_argument(
+        "--target-best-known",
+        action="store_true",
+        help="Use best-known result for the JSON filename as target_fitness.",
+    )
+    stopping.add_argument("--max-evals", type=int)
+    stopping.add_argument("--stall-generations", type=int)
+    stopping.add_argument("--stall-tolerance", type=float, default=1e-9)
+    stopping.add_argument("--fitness-std-tol", type=float)
+    stopping.add_argument("--std-generations", type=int, default=1)
+    stopping.add_argument("--max-unique-schedules", type=int)
+
+    output = parser.add_argument_group("output")
+    output.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory for generated comparison CSV and plot.",
+    )
+    output.add_argument(
+        "--plot-file",
+        type=Path,
+        help="Path for combined convergence plot. Defaults under --output-dir.",
+    )
+    output.add_argument(
+        "--csv-file",
+        type=Path,
+        help="Path for full comparison CSV. Defaults under --output-dir.",
+    )
+    output.add_argument(
+        "--delta-csv-file",
+        type=Path,
+        help="Path for paired mixed-vs-random delta CSV. Defaults under --output-dir.",
+    )
+    output.add_argument(
+        "--no-plot",
+        action="store_true",
+        help="Skip convergence plot generation.",
+    )
+    output.add_argument(
+        "--show",
+        action="store_true",
+        help="Show the convergence plot interactively after saving.",
+    )
+
+    args = parser.parse_args()
+    if args.target_best_known and args.target_fitness is not None:
+        parser.error("--target-best-known and --target-fitness are mutually exclusive.")
+
+    try:
+        args.mutations = _parse_name_list(args.mutations, mutations, "mutation")
+        args.initial_population_modes = _parse_name_list(
+            args.initial_population_modes,
+            initial_modes,
+            "initial population mode",
+        )
+        args.json_path = _resolve_json_path(args.json_input)
+    except (argparse.ArgumentTypeError, FileNotFoundError) as exc:
+        parser.error(str(exc))
+    return args
+
+
+def load_best_known_results() -> dict[str, float]:
+    if not BEST_RESULTS_PATH.exists():
+        return {}
+    with BEST_RESULTS_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_best_known_result(best_results: dict[str, float], json_path: Path) -> float | None:
+    return best_results.get(f"{json_path.stem}.sm")
+
+
+def load_pert(json_path: Path) -> Any:
+    pert = Pert.from_json_file(str(json_path), schema_path=str(SCHEMA))
+    pert.generateInfo()
+    return pert
+
+
+def compute_priority_baseline(json_path: Path) -> dict[str, Any]:
+    """Compute CPM and priority-rule baselines once for the input instance."""
+    pert = load_pert(json_path)
+    cpm_duration = pert.getProjectDuration()
+    n_activities = len(pert.infoDict)
+    serial_durations: dict[str, float] = {}
+    parallel_durations: dict[str, float] = {}
+
+    for rule in PRIORITY_RULES:
+        try:
+            pert.priorities = None
+            s_out = pert.calculateSerialScheduleWithResources(priority_rule=rule)
+            serial_durations[rule] = s_out["scheduled_duration"] - 2
+
+            pert.priorities = None
+            p_out = pert.calculateScheduleWithResources(
+                sgs="max_use_res_ranked",
+                priority_rule=rule,
+            )
+            parallel_durations[rule] = p_out["scheduled_duration"] - 2
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Rule '%s' skipped in baseline: %s", rule, exc)
+
+    best_serial = min(serial_durations.values()) if serial_durations else float("inf")
+    best_parallel = min(parallel_durations.values()) if parallel_durations else float("inf")
+    return {
+        "n_activities": n_activities,
+        "cpm_duration": cpm_duration,
+        "best_serial": best_serial,
+        "best_parallel": best_parallel,
+        "best_rule_overall": min(best_serial, best_parallel),
+    }
+
+
+def _best_series(log: Any) -> tuple[list[float], list[float]]:
+    """Return generation and best-so-far series from a DEAP logbook."""
+    records = list(log)
+    gens = [float(row["gen"]) for row in records]
+    if records and "best" in records[0]:
+        best = [float(row["best"]) for row in records]
+    else:
+        best = []
+        current = float("inf")
+        for row in records:
+            current = min(current, float(row["min"]))
+            best.append(current)
+    return gens, best
+
+
+def run_case(
+    json_path: Path,
+    mutation: str,
+    initial_population_mode: str,
+    args: argparse.Namespace,
+    target_fitness: float | None,
+    best_rule_overall: float,
+    best_known: float | None,
+) -> dict[str, Any]:
+    """Run one mutation/initialization-mode combination on a fresh Pert instance."""
+    print(
+        "Running GA: "
+        f"crossover={FIXED_CROSSOVER}, mutation={mutation}, "
+        f"initial_population_mode={initial_population_mode}"
+    )
+    pert = load_pert(json_path)
+    ga = RCPSPGeneticAlgorithm(
+        pert,
+        pop_size=args.pop_size,
+        n_gen=args.n_gen,
+        cxpb=args.cxpb,
+        mutpb=args.mutpb,
+        seed=args.seed,
+        n_random=args.n_random,
+        hof_size=args.hof_size,
+        verbose=not args.quiet,
+        crossover=FIXED_CROSSOVER,
+        mutation=mutation,
+        fb_improvement=not args.no_fb_improvement,
+        fb_freq=args.fb_freq,
+        initial_population_mode=initial_population_mode,
+        target_fitness=target_fitness,
+        max_evals=args.max_evals,
+        stall_generations=args.stall_generations,
+        stall_tolerance=args.stall_tolerance,
+        fitness_std_tol=args.fitness_std_tol,
+        std_generations=args.std_generations,
+        max_unique_schedules=args.max_unique_schedules,
+        consensus_update_freq=args.consensus_update_freq,
+        consensus_elite_frac=args.consensus_elite_frac,
+    )
+    hof, log = ga.run()
+    best_result = ga.get_best_schedule(hof)
+    best_ga = best_result["scheduled_duration"] - 2
+    summary = ga.get_convergence_summary(log)
+    gens, best_curve = _best_series(log)
+
+    return {
+        "crossover": FIXED_CROSSOVER,
+        "mutation": mutation,
+        "initial_population_mode": initial_population_mode,
+        "label": f"{initial_population_mode}/{mutation}",
+        "best_ga": best_ga,
+        "logged_best": summary["best_duration"],
+        "initial_best": summary["initial_best"],
+        "improvement_gen0": summary["improvement"],
+        "improvement_vs_seed": best_rule_overall - best_ga,
+        "best_known": best_known,
+        "gap_to_best_known": (
+            best_ga - best_known if best_known is not None else float("nan")
+        ),
+        "final_avg": summary["final_avg"],
+        "final_std": summary["final_std"],
+        "n_gen_executed": summary["n_gen"],
+        "n_evals": summary["n_evals"],
+        "n_unique_schedules": summary["n_unique_schedules"],
+        "stop_reason": summary["stop_reason"],
+        "gens": gens,
+        "best_curve": best_curve,
+    }
+
+
+def build_delta_rows(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build paired mixed-vs-random comparisons by mutation."""
+    by_mutation: dict[str, dict[str, dict[str, Any]]] = {}
+    for result in results:
+        by_mutation.setdefault(result["mutation"], {})[
+            result["initial_population_mode"]
+        ] = result
+
+    rows: list[dict[str, Any]] = []
+    for mutation in _available_mutations():
+        pair = by_mutation.get(mutation, {})
+        mixed = pair.get("mixed")
+        random_result = pair.get("random")
+        if mixed is None or random_result is None:
+            continue
+        delta = random_result["best_ga"] - mixed["best_ga"]
+        if delta > 0:
+            winner = "mixed"
+        elif delta < 0:
+            winner = "random"
+        else:
+            winner = "tie"
+        rows.append(
+            {
+                "mutation": mutation,
+                "mixed_best_ga": mixed["best_ga"],
+                "random_best_ga": random_result["best_ga"],
+                "delta_random_minus_mixed": delta,
+                "winner": winner,
+                "mixed_gap_to_best_known": mixed["gap_to_best_known"],
+                "random_gap_to_best_known": random_result["gap_to_best_known"],
+                "mixed_initial_best": mixed["initial_best"],
+                "random_initial_best": random_result["initial_best"],
+                "mixed_n_evals": mixed["n_evals"],
+                "random_n_evals": random_result["n_evals"],
+                "mixed_stop_reason": mixed["stop_reason"],
+                "random_stop_reason": random_result["stop_reason"],
+            }
+        )
+    rows.sort(key=lambda row: abs(row["delta_random_minus_mixed"]), reverse=True)
+    return rows
+
+
+def plot_combined_convergence(
+    results: list[dict[str, Any]],
+    filename: Path,
+    title: str,
+    show: bool = False,
+) -> None:
+    """Plot best-so-far convergence curves for all runs."""
+    import matplotlib
+
+    matplotlib.use("Agg", force=not show)
+    import matplotlib.pyplot as plt
+
+    filename.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(11, 6.5))
+    for result in results:
+        linestyle = "-" if result["initial_population_mode"] == "mixed" else "--"
+        ax.plot(
+            result["gens"],
+            result["best_curve"],
+            linestyle=linestyle,
+            linewidth=1.6,
+            label=result["label"],
+        )
+        if result["gens"] and result["best_curve"]:
+            ax.scatter(
+                result["gens"][-1],
+                result["best_curve"][-1],
+                s=18,
+                zorder=3,
+            )
+
+    ax.set_title(title)
+    ax.set_xlabel("Generation")
+    ax.set_ylabel("Best-so-far duration (h)")
+    ax.grid(True, linestyle=":", linewidth=0.8, alpha=0.7)
+    ax.legend(fontsize=8, ncol=2)
+    fig.tight_layout()
+    fig.savefig(filename, dpi=150, bbox_inches="tight")
+    if show:
+        plt.show()
+    plt.close(fig)
+
+
+def write_csv(results: list[dict[str, Any]], filename: Path) -> None:
+    filename.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "rank",
+        "crossover",
+        "mutation",
+        "initial_population_mode",
+        "best_ga",
+        "gap_to_best_known",
+        "improvement_vs_seed",
+        "initial_best",
+        "logged_best",
+        "improvement_gen0",
+        "final_avg",
+        "final_std",
+        "n_gen_executed",
+        "n_evals",
+        "n_unique_schedules",
+        "stop_reason",
+    ]
+    with filename.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for rank, result in enumerate(results, start=1):
+            row = {field: result.get(field) for field in fields}
+            row["rank"] = rank
+            writer.writerow(row)
+
+
+def write_delta_csv(delta_rows: list[dict[str, Any]], filename: Path) -> None:
+    filename.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "mutation",
+        "mixed_best_ga",
+        "random_best_ga",
+        "delta_random_minus_mixed",
+        "winner",
+        "mixed_gap_to_best_known",
+        "random_gap_to_best_known",
+        "mixed_initial_best",
+        "random_initial_best",
+        "mixed_n_evals",
+        "random_n_evals",
+        "mixed_stop_reason",
+        "random_stop_reason",
+    ]
+    with filename.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(delta_rows)
+
+
+def print_full_comparison(
+    results: list[dict[str, Any]],
+    baseline: dict[str, Any],
+    best_known: float | None,
+) -> None:
+    print()
+    print("=" * 124)
+    print("GA INITIAL POPULATION COMPARISON")
+    print("=" * 124)
+    print(f"Activities        : {baseline['n_activities']}")
+    print(f"CPM duration      : {baseline['cpm_duration']:.2f} h")
+    print(f"Best serial seed  : {baseline['best_serial']:.2f} h")
+    print(f"Best parallel seed: {baseline['best_parallel']:.2f} h")
+    print(f"Best known        : {_safe_float(best_known)} h")
+    print(f"Crossover         : {FIXED_CROSSOVER}")
+    print("-" * 124)
+    print(
+        f"{'Rank':>4} {'Init Mode':<10} {'Mutation':<18} "
+        f"{'Best':>8} {'BK Gap':>8} {'Seed Gap':>9} "
+        f"{'Initial':>8} {'Gen':>5} {'Evals':>8} {'Avg/Std':>17} {'Stop':>20}"
+    )
+    print("-" * 124)
+    for rank, r in enumerate(results, start=1):
+        avg_std = f"{r['final_avg']:.2f}/{r['final_std']:.2f}"
+        print(
+            f"{rank:>4} {r['initial_population_mode']:<10} {r['mutation']:<18} "
+            f"{r['best_ga']:>8.2f} {_safe_float(r['gap_to_best_known']):>8} "
+            f"{r['improvement_vs_seed']:>9.2f} {r['initial_best']:>8.2f} "
+            f"{r['n_gen_executed']:>5} {r['n_evals']:>8} "
+            f"{avg_std:>17} {r['stop_reason']:>20}"
+        )
+    print("-" * 124)
+    best = results[0]
+    print(
+        "Best run: "
+        f"{best['initial_population_mode']} initialization + "
+        f"{best['mutation']} mutation with final duration "
+        f"{best['best_ga']:.2f} h"
+    )
+
+
+def print_delta_comparison(delta_rows: list[dict[str, Any]]) -> None:
+    if not delta_rows:
+        return
+
+    print()
+    print("=" * 90)
+    print("MIXED VS RANDOM BY MUTATION")
+    print("=" * 90)
+    print(
+        f"{'Mutation':<18} {'Mixed':>8} {'Random':>8} "
+        f"{'Random-Mixed':>14} {'Winner':>10} "
+        f"{'Mixed Init':>11} {'Random Init':>12}"
+    )
+    print("-" * 90)
+    for row in delta_rows:
+        print(
+            f"{row['mutation']:<18} "
+            f"{row['mixed_best_ga']:>8.2f} "
+            f"{row['random_best_ga']:>8.2f} "
+            f"{row['delta_random_minus_mixed']:>14.2f} "
+            f"{row['winner']:>10} "
+            f"{row['mixed_initial_best']:>11.2f} "
+            f"{row['random_initial_best']:>12.2f}"
+        )
+    print("-" * 90)
+    print("Positive Random-Mixed means mixed initialization produced a shorter schedule.")
+
+
+def main() -> None:
+    args = parse_args()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    best_results = load_best_known_results()
+    best_known = get_best_known_result(best_results, args.json_path)
+    target_fitness = best_known if args.target_best_known else args.target_fitness
+    baseline = compute_priority_baseline(args.json_path)
+
+    print("=" * 84)
+    print(f"Input                    : {args.json_path}")
+    print(f"Crossover                : {FIXED_CROSSOVER}")
+    print(f"Mutations                : {', '.join(args.mutations)}")
+    print(f"Initial population modes : {', '.join(args.initial_population_modes)}")
+    print(f"Runs                     : {len(args.mutations) * len(args.initial_population_modes)}")
+    print("=" * 84)
+
+    results: list[dict[str, Any]] = []
+    for mutation in args.mutations:
+        for mode in args.initial_population_modes:
+            result = run_case(
+                args.json_path,
+                mutation,
+                mode,
+                args,
+                target_fitness,
+                baseline["best_rule_overall"],
+                best_known,
+            )
+            results.append(result)
+
+    results.sort(
+        key=lambda r: (
+            r["best_ga"],
+            r["n_evals"],
+            r["mutation"],
+            r["initial_population_mode"],
+        )
+    )
+    delta_rows = build_delta_rows(results)
+
+    stem = args.json_path.stem
+    plot_file = args.plot_file or (
+        args.output_dir / f"{stem}_priority_vs_random_convergence_seed{args.seed}.png"
+    )
+    csv_file = args.csv_file or (
+        args.output_dir / f"{stem}_priority_vs_random_comparison_seed{args.seed}.csv"
+    )
+    delta_csv_file = args.delta_csv_file or (
+        args.output_dir / f"{stem}_priority_vs_random_delta_seed{args.seed}.csv"
+    )
+
+    if not args.no_plot:
+        plot_combined_convergence(
+            results,
+            plot_file,
+            title=f"GA Initial Population Comparison - {stem}",
+            show=args.show,
+        )
+        print(f"Combined convergence plot: {plot_file}")
+
+    write_csv(results, csv_file)
+    print(f"Comparison CSV: {csv_file}")
+    write_delta_csv(delta_rows, delta_csv_file)
+    print(f"Mixed-vs-random delta CSV: {delta_csv_file}")
+
+    print_full_comparison(results, baseline, best_known)
+    print_delta_comparison(delta_rows)
+    if not args.no_fb_improvement:
+        print()
+        print(
+            "Note: convergence curves use the GA logbook. Final FBF polishing can "
+            "improve the table's final duration after the last logged generation."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CPM/ga_test.py
+++ b/src/CPM/ga_test.py
@@ -74,6 +74,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mutpb", type=float, default=0.1)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument(
+        "--initial-population-mode",
+        choices=["mixed", "random", "priority_rules"],
+        default="mixed",
+        help=(
+            "Initial GA population source: priority-rule seeds plus random fill "
+            "(mixed), all random, or deterministic priority rules only."
+        ),
+    )
+    parser.add_argument(
         "--quiet",
         action="store_true",
         help="Disable verbose per-generation output.",
@@ -181,6 +190,7 @@ def run_ga_case(
     mutation: str = 'adjacent_swap',
     fb_improvement: bool = True,
     fb_freq: int = 0,
+    initial_population_mode: str = 'mixed',
     plot_convergence: bool = True,
     plot_dir: str | Path | None = None,
     target_fitness: float | None = None,
@@ -234,6 +244,9 @@ def run_ga_case(
     fb_freq : int
         Also apply FBF every ``fb_freq`` generations during evolution
         (``0`` = only at the end).
+    initial_population_mode : str
+        Initial GA population source: ``'mixed'``, ``'random'``, or
+        ``'priority_rules'``.
     plot_convergence : bool
         Save a convergence plot for the GA logbook returned by ``run()``.
     plot_dir : str or Path, optional
@@ -329,6 +342,7 @@ def run_ga_case(
         mutation=mutation,
         fb_improvement=fb_improvement,
         fb_freq=fb_freq,
+        initial_population_mode=initial_population_mode,
         target_fitness=target_fitness,
         max_evals=max_evals,
         stall_generations=stall_generations,
@@ -438,6 +452,7 @@ def main() -> None:
             mutation=args.mutation,
             fb_improvement=not args.no_fb_improvement,
             fb_freq=args.fb_freq,
+            initial_population_mode=args.initial_population_mode,
             plot_convergence=not args.no_plot,
             plot_dir=args.plot_dir,
             target_fitness=target_fitness,

--- a/src/CPM/ga_test.py
+++ b/src/CPM/ga_test.py
@@ -6,6 +6,7 @@ a comparison table of:
   - Best duration from all named priority rules (serial + parallel SGS)
   - Best GA duration (activity list chromosome + serial SGS decoder)
   - Improvement over the best seeded solution
+  - Convergence plot saved for each case
 
 The GA uses the Activity List representation with configurable crossover
 and mutation operators.  Decoding is performed by the Serial SGS.
@@ -22,13 +23,18 @@ Usage (from the src/CPM directory):
 
 Or from the repo root:
     python -m src.CPM.ga_test
+
+Examples:
+    python -m src.CPM.ga_test --max-evals 5000
+    python -m src.CPM.ga_test --stall-generations 25 --fitness-std-tol 0.01
+    python -m src.CPM.ga_test --target-best-known --case j30
 """
 
-import sys
+import argparse
 import logging
 import json
+import sys
 from pathlib import Path
-
 
 
 # Ensure repo root is on the path before project imports
@@ -41,6 +47,7 @@ logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 SCHEMA = Path(__file__).parent / "outage_schema.json"
 BEST_RESULTS_PATH = Path(__file__).parent / "benchmarks" / "best_results.json"
+DEFAULT_PLOT_DIR = Path(__file__).parent / "results" / "ga_convergence"
 
 CASES = [
     ("j30",  "j301_1.json"),
@@ -48,6 +55,105 @@ CASES = [
     ("j90",  "j901_1.json"),
     ("j120", "j1201_1.json"),
 ]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line options for integration runs."""
+    parser = argparse.ArgumentParser(
+        description="Run RCPSP GA benchmark cases with optional stopping criteria.",
+    )
+    parser.add_argument(
+        "--case",
+        choices=[name for name, _ in CASES],
+        action="append",
+        help="Run only the selected case. May be supplied more than once.",
+    )
+    parser.add_argument("--pop-size", type=int, default=50)
+    parser.add_argument("--n-gen", type=int, default=100)
+    parser.add_argument("--cxpb", type=float, default=0.9)
+    parser.add_argument("--mutpb", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Disable verbose per-generation output.",
+    )
+    parser.add_argument(
+        "--crossover",
+        default="two_point",
+        choices=["one_point", "two_point", "uniform_order"],
+    )
+    parser.add_argument(
+        "--mutation",
+        default="adjacent_swap",
+        choices=["swap", "adjacent_swap", "insertion_window"],
+    )
+    parser.add_argument(
+        "--no-fb-improvement",
+        action="store_true",
+        help="Disable final Forward-Backward-Forward improvement.",
+    )
+    parser.add_argument("--fb-freq", type=int, default=0)
+    parser.add_argument(
+        "--no-plot",
+        action="store_true",
+        help="Do not save convergence plots.",
+    )
+    parser.add_argument(
+        "--plot-dir",
+        type=Path,
+        default=DEFAULT_PLOT_DIR,
+        help="Directory for convergence plots.",
+    )
+
+    stopping = parser.add_argument_group("stopping criteria")
+    stopping.add_argument(
+        "--target-fitness",
+        type=float,
+        help="Stop when GA best fitness/duration is <= this value.",
+    )
+    stopping.add_argument(
+        "--target-best-known",
+        action="store_true",
+        help="Use each case's PSPLIB best-known result as target_fitness.",
+    )
+    stopping.add_argument(
+        "--max-evals",
+        type=int,
+        help="Stop before a generation would exceed this many GA evaluations.",
+    )
+    stopping.add_argument(
+        "--stall-generations",
+        type=int,
+        help="Stop after this many generations without best-fitness improvement.",
+    )
+    stopping.add_argument(
+        "--stall-tolerance",
+        type=float,
+        default=1e-9,
+        help="Minimum improvement needed to reset the stall counter.",
+    )
+    stopping.add_argument(
+        "--fitness-std-tol",
+        type=float,
+        help="Stop when population fitness std stays at or below this value.",
+    )
+    stopping.add_argument(
+        "--std-generations",
+        type=int,
+        default=1,
+        help="Consecutive low-std generations needed for --fitness-std-tol.",
+    )
+    stopping.add_argument(
+        "--max-unique-schedules",
+        type=int,
+        help="Stop after observing this many unique decoded schedules.",
+    )
+
+    args = parser.parse_args()
+    if args.target_best_known and args.target_fitness is not None:
+        parser.error("--target-best-known and --target-fitness are mutually exclusive.")
+    return args
 
 
 def load_best_known_results() -> dict[str, float]:
@@ -75,6 +181,15 @@ def run_ga_case(
     mutation: str = 'adjacent_swap',
     fb_improvement: bool = True,
     fb_freq: int = 0,
+    plot_convergence: bool = True,
+    plot_dir: str | Path | None = None,
+    target_fitness: float | None = None,
+    max_evals: int | None = None,
+    stall_generations: int | None = None,
+    stall_tolerance: float = 1e-9,
+    fitness_std_tol: float | None = None,
+    std_generations: int = 1,
+    max_unique_schedules: int | None = None,
 ) -> dict:
     """
     Run the GA on a single PSPLIB benchmark case.
@@ -119,6 +234,27 @@ def run_ga_case(
     fb_freq : int
         Also apply FBF every ``fb_freq`` generations during evolution
         (``0`` = only at the end).
+    plot_convergence : bool
+        Save a convergence plot for the GA logbook returned by ``run()``.
+    plot_dir : str or Path, optional
+        Directory for convergence plots.  Defaults to
+        ``src/CPM/results/ga_convergence``.
+    target_fitness : float, optional
+        Stop when the GA best fitness/duration is at or below this value.
+    max_evals : int, optional
+        Stop before starting a generation that would exceed this evaluation
+        budget.
+    stall_generations : int, optional
+        Stop after this many generations without best-fitness improvement.
+    stall_tolerance : float
+        Minimum best-fitness decrease required to reset the stall counter.
+    fitness_std_tol : float, optional
+        Stop when population fitness standard deviation stays at or below this
+        threshold for ``std_generations`` generations.
+    std_generations : int
+        Consecutive low-variance generations required by ``fitness_std_tol``.
+    max_unique_schedules : int, optional
+        Stop after observing this many unique decoded schedules.
 
     Returns
     -------
@@ -193,8 +329,45 @@ def run_ga_case(
         mutation=mutation,
         fb_improvement=fb_improvement,
         fb_freq=fb_freq,
+        target_fitness=target_fitness,
+        max_evals=max_evals,
+        stall_generations=stall_generations,
+        stall_tolerance=stall_tolerance,
+        fitness_std_tol=fitness_std_tol,
+        std_generations=std_generations,
+        max_unique_schedules=max_unique_schedules,
     )
     hof, log = ga.run()
+
+    plot_path = None
+    if plot_convergence:
+        out_dir = Path(plot_dir) if plot_dir is not None else DEFAULT_PLOT_DIR
+        out_dir.mkdir(parents=True, exist_ok=True)
+        plot_path = (
+            out_dir
+            / f"{case_name}_ga_convergence_{crossover}_{mutation}_seed{seed}.png"
+        )
+        try:
+            import matplotlib
+
+            matplotlib.use('Agg', force=True)
+            fig, _ = ga.plot_convergence(
+                log,
+                filename=str(plot_path),
+                show=False,
+                title=f"GA Convergence - {case_name}",
+            )
+            import matplotlib.pyplot as plt
+
+            plt.close(fig)
+            print(f"Convergence plot: {plot_path}")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Could not save convergence plot for %s: %s",
+                case_name,
+                exc,
+            )
+            plot_path = None
 
     # ── Best schedule from GA ─────────────────────────────────────────────────
     best_result = ga.get_best_schedule(hof)
@@ -211,6 +384,11 @@ def run_ga_case(
     print(f"  Best GA duration              : {best_ga:.2f} h")
     print(f"  Improvement over best seed    : {best_rule_overall - best_ga:.2f} h")
     print(f"  GA improvement (gen0 → final) : {summary['improvement']:.2f} h")
+    print(f"  Stop reason                   : {summary['stop_reason']}")
+    print(f"  Generations executed          : {summary['n_gen']} / {n_gen}")
+    print(f"  GA evaluations                : {summary['n_evals']}")
+    if max_unique_schedules is not None:
+        print(f"  Unique schedules              : {summary['n_unique_schedules']}")
     avg_std = f"{summary['final_avg']:.2f} / {summary['final_std']:.2f}"
     print(f"  Final avg / std               : {avg_std}")
     print(f"{'─' * 60}")
@@ -226,27 +404,50 @@ def run_ga_case(
         'best_parallel_seed': best_parallel,
         'best_ga': best_ga,
         'improvement': best_rule_overall - best_ga,
+        'convergence_plot': str(plot_path) if plot_path else None,
+        'stop_reason': summary['stop_reason'],
+        'n_gen_executed': summary['n_gen'],
+        'n_evals': summary['n_evals'],
+        'n_unique_schedules': summary['n_unique_schedules'],
     }
 
 
 def main() -> None:
     """Run the GA on all benchmark cases and print a summary table."""
+    args = parse_args()
     best_results = load_best_known_results()
     results = []
-    for case_name, json_file in CASES:
+    selected_cases = (
+        [(name, path) for name, path in CASES if name in set(args.case)]
+        if args.case
+        else CASES
+    )
+    for case_name, json_file in selected_cases:
+        best_known = get_best_known_result(best_results, json_file)
+        target_fitness = best_known if args.target_best_known else args.target_fitness
         result = run_ga_case(
             case_name=case_name,
             json_file=json_file,
-            pop_size=50,
-            n_gen=100,
-            cxpb=0.9,
-            mutpb=0.1,
-            seed=42,
-            verbose=True,
-            fb_improvement=True,
-            fb_freq=0,
+            pop_size=args.pop_size,
+            n_gen=args.n_gen,
+            cxpb=args.cxpb,
+            mutpb=args.mutpb,
+            seed=args.seed,
+            verbose=not args.quiet,
+            crossover=args.crossover,
+            mutation=args.mutation,
+            fb_improvement=not args.no_fb_improvement,
+            fb_freq=args.fb_freq,
+            plot_convergence=not args.no_plot,
+            plot_dir=args.plot_dir,
+            target_fitness=target_fitness,
+            max_evals=args.max_evals,
+            stall_generations=args.stall_generations,
+            stall_tolerance=args.stall_tolerance,
+            fitness_std_tol=args.fitness_std_tol,
+            std_generations=args.std_generations,
+            max_unique_schedules=args.max_unique_schedules,
         )
-        best_known = get_best_known_result(best_results, json_file)
         result['best_known'] = best_known
         result['ga_vs_best_known'] = (
             result['best_ga'] - best_known if best_known is not None else float('nan')
@@ -255,20 +456,27 @@ def main() -> None:
 
     # ── Summary table ─────────────────────────────────────────────────────────
     print("\n" + "=" * 80)
-    print("SUMMARY — GA (Activity List, two-point crossover, adjacent-swap mutation, Serial SGS)")
+    print(
+        "SUMMARY — GA "
+        f"(Activity List, {args.crossover} crossover, "
+        f"{args.mutation} mutation, Serial SGS)"
+    )
     print("=" * 80)
     print(
         f"  {'Case':<8} {'N':>6} {'CPM (h)':>10} "
         f"{'Best Serial':>13} {'Best Parallel':>14} {'Best GA':>10} "
-        f"{'Best Known':>12} {'GA-BK':>8} {'Δ (h)':>8}"
+        f"{'Best Known':>12} {'GA-BK':>8} {'Δ (h)':>8} "
+        f"{'Gen':>6} {'Evals':>8} {'Stop':>20}"
     )
-    print("  " + "-" * 94)
+    print("  " + "-" * 130)
     for r in results:
         print(
             f"  {r['case']:<8} {r['n_activities']:>6} {r['cpm_duration']:>10.2f} "
             f"{r['best_serial_seed']:>13.2f} {r['best_parallel_seed']:>14.2f} "
             f"{r['best_ga']:>10.2f} {r['best_known']:>12.2f} "
-            f"{r['ga_vs_best_known']:>8.2f} {r['improvement']:>8.2f}"
+            f"{r['ga_vs_best_known']:>8.2f} {r['improvement']:>8.2f} "
+            f"{r['n_gen_executed']:>6} {r['n_evals']:>8} "
+            f"{r['stop_reason']:>20}"
         )
     print()
 

--- a/src/CPM/ga_test.py
+++ b/src/CPM/ga_test.py
@@ -73,6 +73,8 @@ def run_ga_case(
     verbose: bool = True,
     crossover: str = 'two_point',
     mutation: str = 'adjacent_swap',
+    fb_improvement: bool = True,
+    fb_freq: int = 0,
 ) -> dict:
     """
     Run the GA on a single PSPLIB benchmark case.
@@ -111,6 +113,12 @@ def run_ga_case(
     mutation : str
         Mutation operator name passed to ``RCPSPGeneticAlgorithm``.
         One of ``'swap'``, ``'adjacent_swap'``, ``'insertion_window'``.
+    fb_improvement : bool
+        Apply Forward-Backward-Forward local improvement as a final
+        polishing step on the full population.  Default ``True``.
+    fb_freq : int
+        Also apply FBF every ``fb_freq`` generations during evolution
+        (``0`` = only at the end).
 
     Returns
     -------
@@ -183,6 +191,8 @@ def run_ga_case(
         verbose=verbose,
         crossover=crossover,
         mutation=mutation,
+        fb_improvement=fb_improvement,
+        fb_freq=fb_freq,
     )
     hof, log = ga.run()
 
@@ -233,6 +243,8 @@ def main() -> None:
             mutpb=0.1,
             seed=42,
             verbose=True,
+            fb_improvement=True,
+            fb_freq=0,
         )
         best_known = get_best_known_result(best_results, json_file)
         result['best_known'] = best_known

--- a/src/CPM/ga_test.py
+++ b/src/CPM/ga_test.py
@@ -26,6 +26,7 @@ Or from the repo root:
 
 import sys
 import logging
+import json
 from pathlib import Path
 
 
@@ -39,6 +40,7 @@ from src.CPM.ga import RCPSPGeneticAlgorithm, PRIORITY_RULES  # noqa: E402
 logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 SCHEMA = Path(__file__).parent / "outage_schema.json"
+BEST_RESULTS_PATH = Path(__file__).parent / "benchmarks" / "best_results.json"
 
 CASES = [
     ("j30",  "j301_1.json"),
@@ -46,6 +48,18 @@ CASES = [
     ("j90",  "j901_1.json"),
     ("j120", "j1201_1.json"),
 ]
+
+
+def load_best_known_results() -> dict[str, float]:
+    """Load PSPLIB best-known results keyed by `<instance>.sm`."""
+    with BEST_RESULTS_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_best_known_result(best_results: dict[str, float], json_file: str) -> float | None:
+    """Resolve the benchmark JSON filename to the corresponding PSPLIB result key."""
+    instance_key = f"{Path(json_file).stem}.sm"
+    return best_results.get(instance_key)
 
 
 def run_ga_case(
@@ -207,6 +221,7 @@ def run_ga_case(
 
 def main() -> None:
     """Run the GA on all benchmark cases and print a summary table."""
+    best_results = load_best_known_results()
     results = []
     for case_name, json_file in CASES:
         result = run_ga_case(
@@ -219,6 +234,11 @@ def main() -> None:
             seed=42,
             verbose=True,
         )
+        best_known = get_best_known_result(best_results, json_file)
+        result['best_known'] = best_known
+        result['ga_vs_best_known'] = (
+            result['best_ga'] - best_known if best_known is not None else float('nan')
+        )
         results.append(result)
 
     # ── Summary table ─────────────────────────────────────────────────────────
@@ -227,14 +247,16 @@ def main() -> None:
     print("=" * 80)
     print(
         f"  {'Case':<8} {'N':>6} {'CPM (h)':>10} "
-        f"{'Best Serial':>13} {'Best Parallel':>14} {'Best GA':>10} {'Δ (h)':>8}"
+        f"{'Best Serial':>13} {'Best Parallel':>14} {'Best GA':>10} "
+        f"{'Best Known':>12} {'GA-BK':>8} {'Δ (h)':>8}"
     )
-    print("  " + "-" * 72)
+    print("  " + "-" * 94)
     for r in results:
         print(
             f"  {r['case']:<8} {r['n_activities']:>6} {r['cpm_duration']:>10.2f} "
             f"{r['best_serial_seed']:>13.2f} {r['best_parallel_seed']:>14.2f} "
-            f"{r['best_ga']:>10.2f} {r['improvement']:>8.2f}"
+            f"{r['best_ga']:>10.2f} {r['best_known']:>12.2f} "
+            f"{r['ga_vs_best_known']:>8.2f} {r['improvement']:>8.2f}"
         )
     print()
 

--- a/src/CPM/ga_test_hard.py
+++ b/src/CPM/ga_test_hard.py
@@ -45,15 +45,31 @@ BEST_RESULTS_PATH = Path(__file__).parent / "benchmarks" / "best_results.json"
 CASES = [
     ("j12051_6",  "benchmarks/PSPLIB_Json/j120/j12051_6.json"),
     ("j12031_10", "benchmarks/PSPLIB_Json/j120/j12031_10.json"),
-    # ("j12036_6",  "benchmarks/PSPLIB_Json/j120/j12036_6.json"),
-    # ("j12056_7",  "benchmarks/PSPLIB_Json/j120/j12056_7.json"),
-    # ("j12051_5",  "benchmarks/PSPLIB_Json/j120/j12051_5.json"),
-    # ("j12056_1",  "benchmarks/PSPLIB_Json/j120/j12056_1.json"),
-    # ("j12026_10", "benchmarks/PSPLIB_Json/j120/j12026_10.json"),
-    # ("j12051_7",  "benchmarks/PSPLIB_Json/j120/j12051_7.json"),
-    # ("j12056_5",  "benchmarks/PSPLIB_Json/j120/j12056_5.json"),
-    # ("j12056_9",  "benchmarks/PSPLIB_Json/j120/j12056_9.json"),
+    ("j12036_6",  "benchmarks/PSPLIB_Json/j120/j12036_6.json"),
+    ("j12056_7",  "benchmarks/PSPLIB_Json/j120/j12056_7.json"),
+    ("j12051_5",  "benchmarks/PSPLIB_Json/j120/j12051_5.json"),
+    ("j12056_1",  "benchmarks/PSPLIB_Json/j120/j12056_1.json"),
+    ("j12026_10", "benchmarks/PSPLIB_Json/j120/j12026_10.json"),
+    ("j12051_7",  "benchmarks/PSPLIB_Json/j120/j12051_7.json"),
+    ("j12056_5",  "benchmarks/PSPLIB_Json/j120/j12056_5.json"),
+    ("j12056_9",  "benchmarks/PSPLIB_Json/j120/j12056_9.json"),
 ]
+
+# ================================================================================
+# SUMMARY — GA (Activity List, two-point crossover, adjacent-swap mutation, Serial SGS)
+# ================================================================================
+#   Case              N    CPM (h)   Best Serial  Best Parallel    Best GA   Best Known    GA-BK    Δ (h)
+#   --------------------------------------------------------------------------------------------------
+#   j12051_6        122     106.00        262.00         256.00     230.00       214.00    16.00    26.00
+#   j12031_10       122      92.00        285.00         266.00     254.00       225.00    29.00    12.00
+#   j12036_6        122     103.00        271.00         263.00     251.00       224.00    27.00    12.00
+#   j12056_7        122     119.00        336.00         320.00     303.00       282.00    21.00    17.00
+#   j12051_5        122     104.00        280.00         266.00     259.00       229.00    30.00     7.00
+#   j12056_1        122      97.00        279.00         273.00     259.00       236.00    23.00    14.00
+#   j12026_10       122     124.00        224.00         219.00     200.00       183.00    17.00    19.00
+#   j12051_7        122      93.00        254.00         247.00     235.00       211.00    24.00    12.00
+#   j12056_5        122     119.00        338.00         315.00     309.00       279.00    30.00     6.00
+#   j12056_9        122     103.00        341.00         325.00     314.00       287.00    27.00    11.00
 
 
 def load_best_known_results() -> dict[str, float]:
@@ -226,7 +242,7 @@ def main() -> None:
             case_name=case_name,
             json_file=json_file,
             pop_size=50,
-            n_gen=1000,
+            n_gen=500,
             cxpb=0.9,
             mutpb=0.5,
             n_random=0,

--- a/src/CPM/ga_test_hard.py
+++ b/src/CPM/ga_test_hard.py
@@ -1,0 +1,266 @@
+"""
+ga_test_hard.py — Hard-instance integration test for the RCPSP Genetic Algorithm (ga.py)
+
+Runs the GA on a selected set of difficult PSPLIB j120 benchmark instances and prints
+a comparison table of:
+  - Best duration from all named priority rules (serial + parallel SGS)
+  - Best GA duration (activity list chromosome + serial SGS decoder)
+  - Improvement over the best seeded solution
+
+The GA uses the Activity List representation with configurable crossover
+and mutation operators.  Decoding is performed by the Serial SGS.
+Default operators: two-point crossover, adjacent-swap mutation.
+
+Reference
+---------
+Kolisch, R. and Hartmann, S. (1999). Heuristic Algorithms for Solving the
+Resource-Constrained Project Scheduling Problem. In J. Weglarz (ed.),
+Project Scheduling: Recent Models, Algorithms and Applications, 147-178.
+
+Usage (from the src/CPM directory):
+    python ga_test_hard.py
+
+Or from the repo root:
+    python -m src.CPM.ga_test_hard
+"""
+
+import sys
+import logging
+import json
+from pathlib import Path
+
+
+
+# Ensure repo root is on the path before project imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src import Pert  # noqa: E402
+from src.CPM.ga import RCPSPGeneticAlgorithm, PRIORITY_RULES  # noqa: E402
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+SCHEMA = Path(__file__).parent / "outage_schema.json"
+BEST_RESULTS_PATH = Path(__file__).parent / "benchmarks" / "best_results.json"
+
+CASES = [
+    ("j12051_6",  "benchmarks/PSPLIB_Json/j120/j12051_6.json"),
+    ("j12031_10", "benchmarks/PSPLIB_Json/j120/j12031_10.json"),
+    # ("j12036_6",  "benchmarks/PSPLIB_Json/j120/j12036_6.json"),
+    # ("j12056_7",  "benchmarks/PSPLIB_Json/j120/j12056_7.json"),
+    # ("j12051_5",  "benchmarks/PSPLIB_Json/j120/j12051_5.json"),
+    # ("j12056_1",  "benchmarks/PSPLIB_Json/j120/j12056_1.json"),
+    # ("j12026_10", "benchmarks/PSPLIB_Json/j120/j12026_10.json"),
+    # ("j12051_7",  "benchmarks/PSPLIB_Json/j120/j12051_7.json"),
+    # ("j12056_5",  "benchmarks/PSPLIB_Json/j120/j12056_5.json"),
+    # ("j12056_9",  "benchmarks/PSPLIB_Json/j120/j12056_9.json"),
+]
+
+
+def load_best_known_results() -> dict[str, float]:
+    """Load PSPLIB best-known results keyed by `<instance>.sm`."""
+    with BEST_RESULTS_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_best_known_result(best_results: dict[str, float], json_file: str) -> float | None:
+    """Resolve the benchmark JSON filename to the corresponding PSPLIB result key."""
+    instance_key = f"{Path(json_file).stem}.sm"
+    return best_results.get(instance_key)
+
+
+def run_ga_case(
+    case_name: str,
+    json_file: str,
+    pop_size: int = 30,
+    n_gen: int = 500,
+    cxpb: float = 0.8,
+    mutpb: float = 0.1,
+    n_random=8,
+    seed: int = 42,
+    verbose: bool = True,
+    crossover: str = 'two_point',
+    mutation: str = 'adjacent_swap',
+) -> dict:
+    """
+    Run the GA on a single PSPLIB benchmark case.
+
+    Parameters
+    ----------
+    case_name : str
+        Human-readable label (e.g. 'j12051_6').
+    json_file : str
+        Path to the input JSON relative to this file's directory.
+    pop_size : int
+        GA population size.
+    n_gen : int
+        Number of GA generations.
+    cxpb : float
+        Crossover probability.
+    mutpb : float
+        Per-individual mutation probability.
+    seed : int
+        RNG seed.
+    verbose : bool
+        Print per-generation stats and seeding table.
+    crossover : str
+        Crossover operator name passed to ``RCPSPGeneticAlgorithm``.
+        One of ``'one_point'``, ``'two_point'``, ``'uniform_order'``.
+    mutation : str
+        Mutation operator name passed to ``RCPSPGeneticAlgorithm``.
+        One of ``'swap'``, ``'adjacent_swap'``, ``'insertion_window'``.
+
+    Returns
+    -------
+    dict with keys:
+        case, n_activities, cpm_duration,
+        best_serial_seed, best_parallel_seed, best_ga, improvement
+    """
+    json_path = Path(__file__).parent / json_file
+
+    print("=" * 70)
+    print(f"Case: {case_name}  ({json_file})")
+    print("=" * 70)
+
+    # ── Load and initialise Pert model ───────────────────────────────────────
+    pert = Pert.from_json_file(str(json_path), schema_path=str(SCHEMA))
+    pert.generateInfo()
+
+    cpm_duration = pert.getProjectDuration()
+    n_activities = len(pert.infoDict)
+
+    print(f"Activities      : {n_activities}")
+    print(f"CPM duration    : {cpm_duration:.2f} h  (unconstrained)")
+    print()
+
+    # ── Baseline: best duration from all named priority rules ─────────────────
+    serial_durations = {}
+    parallel_durations = {}
+
+    for rule in PRIORITY_RULES:
+        try:
+            pert.priorities = None
+            s_out = pert.calculateSerialScheduleWithResources(priority_rule=rule)
+            serial_durations[rule] = s_out['scheduled_duration'] - 2
+
+            pert.priorities = None
+            p_out = pert.calculateScheduleWithResources(
+                sgs='max_use_res_ranked', priority_rule=rule
+            )
+            parallel_durations[rule] = p_out['scheduled_duration'] - 2
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Rule '%s' skipped in baseline: %s", rule, exc)
+
+    best_serial = (
+        min(serial_durations.values()) if serial_durations else float('inf')
+    )
+    best_parallel = (
+        min(parallel_durations.values()) if parallel_durations else float('inf')
+    )
+    best_rule_overall = min(best_serial, best_parallel)
+
+    if verbose:
+        print("Priority rule baseline durations:")
+        print(f"  {'Rule':<22} {'Serial (h)':>12} {'Parallel (h)':>14}")
+        print("  " + "-" * 50)
+        for rule in PRIORITY_RULES:
+            s = serial_durations.get(rule, float('nan'))
+            p = parallel_durations.get(rule, float('nan'))
+            print(f"  {rule:<22} {s:>12.2f} {p:>14.2f}")
+        print()
+
+    # ── Run GA ───────────────────────────────────────────────────────────────
+    print(f"Running GA (crossover={crossover!r}, mutation={mutation!r}, Serial SGS)...")
+    ga = RCPSPGeneticAlgorithm(
+        pert,
+        pop_size=pop_size,
+        n_gen=n_gen,
+        cxpb=cxpb,
+        mutpb=mutpb,
+        n_random=n_random,
+        seed=seed,
+        verbose=verbose,
+        crossover=crossover,
+        mutation=mutation,
+    )
+    hof, log = ga.run()
+
+    # ── Best schedule from GA ─────────────────────────────────────────────────
+    best_result = ga.get_best_schedule(hof)
+    best_ga = best_result['scheduled_duration'] - 2
+
+    summary = ga.get_convergence_summary(log)
+    best_activity_list = ga.get_best_activity_list(hof)
+
+    print()
+    print(f"{'─' * 60}")
+    print(f"  CPM duration (unconstrained)  : {cpm_duration:.2f} h")
+    print(f"  Best serial SGS  (all rules)  : {best_serial:.2f} h")
+    print(f"  Best parallel SGS (all rules) : {best_parallel:.2f} h")
+    print(f"  Best GA duration              : {best_ga:.2f} h")
+    print(f"  Improvement over best seed    : {best_rule_overall - best_ga:.2f} h")
+    print(f"  GA improvement (gen0 → final) : {summary['improvement']:.2f} h")
+    avg_std = f"{summary['final_avg']:.2f} / {summary['final_std']:.2f}"
+    print(f"  Final avg / std               : {avg_std}")
+    print(f"{'─' * 60}")
+    first_ten = best_activity_list[:10]
+    print(f"  Best activity list (first 10) : {first_ten}")
+    print()
+
+    return {
+        'case': case_name,
+        'n_activities': n_activities,
+        'cpm_duration': cpm_duration,
+        'best_serial_seed': best_serial,
+        'best_parallel_seed': best_parallel,
+        'best_ga': best_ga,
+        'improvement': best_rule_overall - best_ga,
+    }
+
+
+def main() -> None:
+    """Run the GA on all hard j120 benchmark cases and print a summary table."""
+    best_results = load_best_known_results()
+    results = []
+    for case_name, json_file in CASES:
+        result = run_ga_case(
+            case_name=case_name,
+            json_file=json_file,
+            pop_size=50,
+            n_gen=500,
+            cxpb=0.9,
+            mutpb=0.5,
+            n_random=0,
+            seed=42,
+            verbose=False,
+            crossover='two_point',
+            mutation='consensus_reorder',
+        )
+        best_known = get_best_known_result(best_results, json_file)
+        result['best_known'] = best_known
+        result['ga_vs_best_known'] = (
+            result['best_ga'] - best_known if best_known is not None else float('nan')
+        )
+        results.append(result)
+
+    # ── Summary table ─────────────────────────────────────────────────────────
+    print("\n" + "=" * 80)
+    print("SUMMARY — GA (Activity List, two-point crossover, adjacent-swap mutation, Serial SGS)")
+    print("=" * 80)
+    print(
+        f"  {'Case':<12} {'N':>6} {'CPM (h)':>10} "
+        f"{'Best Serial':>13} {'Best Parallel':>14} {'Best GA':>10} "
+        f"{'Best Known':>12} {'GA-BK':>8} {'Δ (h)':>8}"
+    )
+    print("  " + "-" * 98)
+    for r in results:
+        print(
+            f"  {r['case']:<12} {r['n_activities']:>6} {r['cpm_duration']:>10.2f} "
+            f"{r['best_serial_seed']:>13.2f} {r['best_parallel_seed']:>14.2f} "
+            f"{r['best_ga']:>10.2f} {r['best_known']:>12.2f} "
+            f"{r['ga_vs_best_known']:>8.2f} {r['improvement']:>8.2f}"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CPM/ga_test_hard.py
+++ b/src/CPM/ga_test_hard.py
@@ -96,6 +96,8 @@ def run_ga_case(
     verbose: bool = True,
     crossover: str = 'two_point',
     mutation: str = 'adjacent_swap',
+    fb_improvement: bool = True,
+    fb_freq: int = 0,
 ) -> dict:
     """
     Run the GA on a single PSPLIB benchmark case.
@@ -124,6 +126,12 @@ def run_ga_case(
     mutation : str
         Mutation operator name passed to ``RCPSPGeneticAlgorithm``.
         One of ``'swap'``, ``'adjacent_swap'``, ``'insertion_window'``.
+    fb_improvement : bool
+        Apply Forward-Backward-Forward local improvement as a final
+        polishing step on the full population.  Default ``True``.
+    fb_freq : int
+        Also apply FBF every ``fb_freq`` generations during evolution
+        (``0`` = only at the end).
 
     Returns
     -------
@@ -197,6 +205,8 @@ def run_ga_case(
         verbose=verbose,
         crossover=crossover,
         mutation=mutation,
+        fb_improvement=fb_improvement,
+        fb_freq=fb_freq,
     )
     hof, log = ga.run()
 
@@ -250,6 +260,8 @@ def main() -> None:
             verbose=False,
             crossover='two_point',
             mutation='consensus_reorder',
+            fb_improvement=True,
+            fb_freq=0,
         )
         best_known = get_best_known_result(best_results, json_file)
         result['best_known'] = best_known

--- a/src/CPM/ga_test_hard.py
+++ b/src/CPM/ga_test_hard.py
@@ -98,6 +98,7 @@ def run_ga_case(
     mutation: str = 'adjacent_swap',
     fb_improvement: bool = True,
     fb_freq: int = 0,
+    initial_population_mode: str = 'mixed',
 ) -> dict:
     """
     Run the GA on a single PSPLIB benchmark case.
@@ -207,6 +208,7 @@ def run_ga_case(
         mutation=mutation,
         fb_improvement=fb_improvement,
         fb_freq=fb_freq,
+        initial_population_mode=initial_population_mode,
     )
     hof, log = ga.run()
 

--- a/src/CPM/ga_test_hard.py
+++ b/src/CPM/ga_test_hard.py
@@ -226,7 +226,7 @@ def main() -> None:
             case_name=case_name,
             json_file=json_file,
             pop_size=50,
-            n_gen=500,
+            n_gen=1000,
             cxpb=0.9,
             mutpb=0.5,
             n_random=0,

--- a/src/CPM/gans.py
+++ b/src/CPM/gans.py
@@ -8,15 +8,15 @@ resource-constrained project scheduling problem" (arXiv:2502.18330v2).
 
 Key algorithmic components
 --------------------------
-- **Resource ranking**: resources ranked by utilisation load; weights guide
+- **Resource ranking**: resources ranked by utilization load; weights guide
   dense-gene selection and GRASP parallel SGS.
-- **Dense genes**: time slots with high weighted resource utilisation; the
+- **Dense genes**: time slots with high weighted resource utilization; the
   activities executing during these slots are preferentially inherited by
   offspring chromosomes.
 - **Crossover A**: greedy merge of dense-gene segments from both parents.
 - **Crossover B**: segment swap based on the outgoing/incoming networks of
   dense-gene activities in the schedule graph G_S.
-- **FBI**: Forward–Backward–Forward improvement (3 SGS calls); applied after
+- **FBI**: Forward-Backward-Forward improvement (3 SGS calls); applied after
   every crossover and mutation operator.
 - **Neighborhood NA**: block reschedule — P activities near a core activity
   are extracted and re-inserted at their earliest feasible positions.
@@ -85,7 +85,7 @@ class RCPSPHybridGANS:
     Parameters
     ----------
     pert : Pert
-        Fully initialised ``Pert`` object with ``generateInfo()`` called.
+        Fully initialized ``Pert`` object with ``generateInfo()`` called.
     pop_size : int
         Population size.  Priority-rule seeds fill up to ``len(PRIORITY_RULES)``
         slots; the rest are random precedence-feasible permutations.
@@ -225,7 +225,7 @@ class RCPSPHybridGANS:
 
     def _rank_resources(self) -> List[str]:
         """
-        Rank resources by utilisation load (most loaded = most scarce).
+        Rank resources by utilization load (most loaded = most scarce).
 
         load_k = sum_j(r_jk * p_j) / (R_k * T_cpm)
         """
@@ -366,10 +366,10 @@ class RCPSPHybridGANS:
         """
         Compute v_t = sum_k (R_k - sum_{j∈J(t)} r_jk) * w_k / R_k
 
-        Returns a value in [0, K] where 0 = fully utilised, K = completely idle.
+        Returns a value in [0, K] where 0 = fully utilized, K = completely idle.
         """
         if not self._skill_ids:
-            # Fallback: proportion of activities running (pseudo-utilisation)
+            # Fallback: proportion of activities running (pseudo-utilization)
             n_total = max(1, len(self._activities))
             return max(0.0, 1.0 - len(active_acts) / n_total)
 
@@ -644,7 +644,7 @@ class RCPSPHybridGANS:
                 if new_pos != cur_pos:
                     gene = order.pop(cur_pos)
                     order.insert(new_pos if new_pos < cur_pos else new_pos - 1, gene)
-
+        order = self._repair(order)
         return self._evaluate_with_fbi(order)
 
     # ------------------------------------------------------------------ #
@@ -765,26 +765,27 @@ class RCPSPHybridGANS:
 
         return block
 
-    def _na_neighbor(self, ind: Individual) -> Optional[Individual]:
+    def _na_neighbor(self, ind: Individual) -> Tuple[Optional[Individual], int]:
         """
         Neighborhood NA: select core activity, extract block, reschedule it.
 
         The block activities are removed from their current order positions and
         re-inserted at their earliest feasible positions in the remaining list.
         """
+        evals_used = 1  # initial decode for timing / block construction
         out = self._decode(ind['order'])
         times = self._get_schedule_times()
         order = self._order_from_schedule(times)
 
         non_dummy = [a for a in self._activities if a not in self._dummy_acts]
         if not non_dummy:
-            return None
+            return None, evals_used
         core = random.choice(non_dummy)
         block = self._create_block(core, times, self._block_size)
 
         if not block:
             self._empty_block_history.append(True)
-            return None
+            return None, evals_used
         self._empty_block_history.append(False)
 
         block_set = {self._act_to_idx[a] for a in block if a in self._act_to_idx}
@@ -818,7 +819,8 @@ class RCPSPHybridGANS:
 
         child_order = self._repair(residual)
         fitness, best_order = self._fbi(child_order)
-        return self._make_individual(best_order, fitness)
+        evals_used += 3  # FBI
+        return self._make_individual(best_order, fitness), evals_used
 
     # ------------------------------------------------------------------ #
     # Neighbourhood NB — split-list GRASP parallel SGS                    #
@@ -832,7 +834,7 @@ class RCPSPHybridGANS:
     ) -> List[Any]:
         """
         Greedy-randomized selection of one activity from the eligible set,
-        maximising weighted resource utilisation.
+        maximizing weighted resource utilization.
 
         Returns a ordering of block_acts chosen by GRASP.
         """
@@ -850,7 +852,7 @@ class RCPSPHybridGANS:
                     / max(self._skill_capacity.get(sk, 1.0), 1.0)
                     for sk in self._skill_ids
                 ) if self._skill_ids else 1.0
-                # Penalise activities that would exceed remaining resource capacity
+                # Penalize activities that would exceed remaining resource capacity
                 feasible = True
                 for sk in self._skill_ids:
                     cap = self._skill_capacity.get(sk, math.inf)
@@ -860,7 +862,7 @@ class RCPSPHybridGANS:
                 scores.append((score if feasible else -1.0, self._act_to_idx.get(a, 0), a))
 
             scores.sort(key=lambda x: x[0], reverse=True)
-            rcl = [a for _, _idx, a in scores[:alpha] if scores[0][0] >= 0]
+            rcl = [a for score, _idx, a in scores[:alpha] if score >= 0]
             if not rcl:
                 rcl = [eligible[0]]
 
@@ -875,24 +877,26 @@ class RCPSPHybridGANS:
 
         return scheduled
 
-    def _nb_neighbor(self, ind: Individual) -> Optional[Individual]:
+    def _nb_neighbor(self, ind: Individual) -> Tuple[Optional[Individual], int]:
         """
         Neighborhood NB: split list L = A1 | block | A2.
 
         A1 scheduled with serial SGS; block with GRASP-parallel SGS; A2 appended.
         """
+        evals_used = 0
         order = list(ind['order'])
         n = len(order)
         non_dummy = [self._activities[i] for i in order
                      if self._activities[i] not in self._dummy_acts]
         if len(non_dummy) < 2:
-            return None
+            return None, evals_used
 
         core = random.choice(non_dummy)
         core_idx = order.index(self._act_to_idx[core])
 
         # Decode for timing to build block
         self._decode(order)
+        evals_used += 1
         times = self._get_schedule_times()
         block_acts = self._create_block(core, times, self._block_size)
 
@@ -902,7 +906,7 @@ class RCPSPHybridGANS:
         # Check: if any block member is a predecessor of core, skip
         preds_of_core = set(self.pert.backwardDict.get(core, []))
         if preds_of_core & set(block_acts):
-            return None
+            return None, evals_used
 
         # Split at core position
         a1_order = [i for i in order[:core_idx] if i not in block_idx_set]
@@ -923,7 +927,8 @@ class RCPSPHybridGANS:
 
         child_order = self._repair(child_order)
         fitness, best_order = self._fbi(child_order)
-        return self._make_individual(best_order, fitness)
+        evals_used += 3  # FBI
+        return self._make_individual(best_order, fitness), evals_used
 
     # ------------------------------------------------------------------ #
     # Adaptive block-size update                                           #
@@ -1064,17 +1069,18 @@ class RCPSPHybridGANS:
                 ns_current = self._make_individual(best['order'], best['fitness'])
                 tabu: List[int] = []
                 tabu_key_current = self._tabu_key(ns_current)
+                n_evals += 1
 
                 for _step in range(self.ns_steps):
                     if n_evals >= self.lambda_max:
                         break
                     ns_type = random.choice(['NA', 'NB'])
-                    neighbor = (
+                    neighbor, neighbor_evals = (
                         self._na_neighbor(ns_current)
                         if ns_type == 'NA'
                         else self._nb_neighbor(ns_current)
                     )
-                    n_evals += 3  # FBI inside neighbor
+                    n_evals += neighbor_evals
 
                     if neighbor is None:
                         continue

--- a/src/CPM/gans.py
+++ b/src/CPM/gans.py
@@ -1,0 +1,1151 @@
+# Copyright 2020, Battelle Energy Alliance, LLC
+# ALL RIGHTS RESERVED
+"""
+gans.py — Hybrid Genetic Algorithm + Neighborhood Search for RCPSP
+
+Implements Goncharov (2025) "A hybrid heuristic algorithm for the
+resource-constrained project scheduling problem" (arXiv:2502.18330v2).
+
+Key algorithmic components
+--------------------------
+- **Resource ranking**: resources ranked by utilisation load; weights guide
+  dense-gene selection and GRASP parallel SGS.
+- **Dense genes**: time slots with high weighted resource utilisation; the
+  activities executing during these slots are preferentially inherited by
+  offspring chromosomes.
+- **Crossover A**: greedy merge of dense-gene segments from both parents.
+- **Crossover B**: segment swap based on the outgoing/incoming networks of
+  dense-gene activities in the schedule graph G_S.
+- **FBI**: Forward–Backward–Forward improvement (3 SGS calls); applied after
+  every crossover and mutation operator.
+- **Neighborhood NA**: block reschedule — P activities near a core activity
+  are extracted and re-inserted at their earliest feasible positions.
+- **Neighborhood NB**: split-list schedule — list is split A1 | block | A2;
+  A1 is built with serial SGS, the block with GRASP-parallel SGS, A2 appended.
+- **GANS main loop**: GA runs until a stall limit, then NS activates; σ-based
+  instance classification adapts the GA/NS effort ratio automatically.
+
+References
+----------
+Goncharov, E.N. (2025). A hybrid heuristic algorithm for the
+resource-constrained project scheduling problem. arXiv:2502.18330v2.
+
+Chromosome representation
+-------------------------
+A **precedence-feasible activity list** — same index encoding as ``ga.py``::
+
+    order = [i₀, i₁, …, i_{N-1}]
+
+where each element is an index into ``self._activities``.
+
+``Individual = {'order': List[int], 'fitness': float}``  — no DEAP dependency.
+
+Requirements
+------------
+    numpy, networkx  (already dependencies of pert.py)
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import random
+from collections import deque
+from datetime import timedelta
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Priority rules for initial-population seeding (mirrors ga.py / gga.py)
+# ---------------------------------------------------------------------------
+PRIORITY_RULES: List[str] = [
+    'es', 'ef', 'ls', 'lf', 'duration', 'random',
+    'mts', 'mtp', 'grpw', 'grd', 'rr', 'avgrr',
+    'maxrr', 'minrr', 'irsm', 'wcs', 'acs',
+    'mehh_8000_b', 'mehh_3375_b', 'mehh_1000_b', 'mehh_125_b', 'gphh_b',
+]
+
+Individual = Dict[str, Any]   # keys: 'order': List[int], 'fitness': float
+
+# Weight sets offered by the paper (Section 8); picked randomly each restart.
+_WEIGHT_SETS: List[Tuple[float, ...]] = [
+    (1.0, 0.8, 0.6, 0.4),
+    (1.0, 0.9, 0.8, 0.7),
+    (1.0, 1.0, 1.0, 1.0),
+]
+
+
+class RCPSPHybridGANS:
+    """
+    Hybrid Genetic Algorithm + Neighbourhood Search for RCPSP.
+
+    Parameters
+    ----------
+    pert : Pert
+        Fully initialised ``Pert`` object with ``generateInfo()`` called.
+    pop_size : int
+        Population size.  Priority-rule seeds fill up to ``len(PRIORITY_RULES)``
+        slots; the rest are random precedence-feasible permutations.
+    lambda_max : int
+        Total budget of SGS evaluations (stopping criterion).
+    ga_stall_limit : int
+        Consecutive GA offspring rounds without improvement before activating NS.
+        Overridden by σ-based instance classification.
+    ns_steps : int
+        NS iterations per activation.  Overridden by σ-based classification.
+    block_size : int
+        Initial ``P`` (number of activities per block) for CreateBlock.
+    resource_threshold : float
+        ``R`` in DenseActivities: weighted residual below this → dense gene.
+    sigma1 : float
+        Lower σ threshold for instance classification.
+    sigma2 : float
+        Upper σ threshold for instance classification.
+    parents_size : int
+        Maximum size of parent pool ``Γ'``.
+    seed : int
+        RNG seed.
+    verbose : bool
+        Print per-generation and NS statistics.
+    """
+
+    def __init__(
+        self,
+        pert,
+        pop_size: int = 60,
+        lambda_max: int = 50_000,
+        ga_stall_limit: int = 50,
+        ns_steps: int = 200,
+        block_size: int = 6,
+        resource_threshold: float = 0.75,
+        sigma1: float = 0.2,
+        sigma2: float = 0.6,
+        parents_size: int = 10,
+        seed: int = 42,
+        verbose: bool = True,
+    ) -> None:
+        self.pert = pert
+        self.pop_size = max(4, pop_size)
+        self.lambda_max = lambda_max
+        self.ga_stall_limit = ga_stall_limit
+        self.ns_steps = ns_steps
+        self.block_size = block_size
+        self.resource_threshold = resource_threshold
+        self.sigma1 = sigma1
+        self.sigma2 = sigma2
+        self.parents_size = min(parents_size, pop_size)
+        self.verbose = verbose
+
+        random.seed(seed)
+        np.random.seed(seed)
+
+        # Fixed activity list (matches forwardDict insertion order)
+        self._activities: List[Any] = list(pert.forwardDict.keys())
+        self._n: int = len(self._activities)
+        self._act_to_idx: Dict[Any, int] = {a: i for i, a in enumerate(self._activities)}
+
+        # Dummy START/END activities excluded from operator targets
+        _start = getattr(pert, 'startActivity', None)
+        _end   = getattr(pert, 'endActivity',   None)
+        self._dummy_acts: FrozenSet[Any] = frozenset(
+            a for a in [_start, _end] if a is not None
+        )
+
+        # CPM duration (used for σ computation)
+        self._cpm_duration: float = pert.getProjectDuration() if hasattr(pert, 'getProjectDuration') else 1.0
+
+        # Build resource info; gracefully degrade if resource pool unavailable
+        self._build_resource_info()
+        self._randomize_weights()
+
+        # Adaptive block-size state
+        self._block_size: int = block_size
+        self._empty_block_history: List[bool] = []
+
+        # Topological order for tie-breaking (used in _order_from_schedule)
+        self._topo_idx: Dict[Any, int] = self._build_topo_idx()
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers                                                  #
+    # ------------------------------------------------------------------ #
+
+    def _build_topo_idx(self) -> Dict[Any, int]:
+        """Return a topological-order index for each activity."""
+        import networkx as nx
+        g = getattr(self.pert, 'nxgraph', None)
+        if g is not None:
+            topo = [a for a in nx.topological_sort(g) if a in self._act_to_idx]
+        else:
+            in_deg: Dict[Any, int] = {a: 0 for a in self._activities}
+            for u, succs in self.pert.forwardDict.items():
+                for v in succs:
+                    if v in in_deg:
+                        in_deg[v] += 1
+            q: deque = deque(a for a in self._activities if in_deg[a] == 0)
+            topo = []
+            while q:
+                u = q.popleft(); topo.append(u)
+                for v in self.pert.forwardDict.get(u, []):
+                    if v in in_deg:
+                        in_deg[v] -= 1
+                        if in_deg[v] == 0:
+                            q.append(v)
+        return {a: i for i, a in enumerate(topo)}
+
+    def _build_resource_info(self) -> None:
+        """Extract resource IDs, capacities, and per-activity demands."""
+        rp = getattr(self.pert, 'resource_pool', None)
+        self._skill_ids: List[str] = []
+        self._skill_capacity: Dict[str, float] = {}
+        self._activity_demand: Dict[Any, Dict[str, float]] = {}
+
+        if rp is not None:
+            try:
+                self._skill_ids = list(rp.get_all_skills())
+                for sk in self._skill_ids:
+                    self._skill_capacity[sk] = float(
+                        rp.resources[sk].get_max_availability()
+                    )
+            except Exception:
+                self._skill_ids = []
+
+        for a in self._activities:
+            req = getattr(a, 'required_resources', []) or []
+            demand: Dict[str, float] = {}
+            for item in req:
+                if isinstance(item, dict):
+                    sk = item.get('skill_type') or item.get('resource_type', '')
+                    cnt = float(item.get('crew_count', item.get('count', 1)))
+                    if sk:
+                        demand[sk] = demand.get(sk, 0.0) + cnt
+            self._activity_demand[a] = demand
+
+    def _rank_resources(self) -> List[str]:
+        """
+        Rank resources by utilisation load (most loaded = most scarce).
+
+        load_k = sum_j(r_jk * p_j) / (R_k * T_cpm)
+        """
+        if not self._skill_ids:
+            return []
+        loads: Dict[str, float] = {}
+        denom = max(self._cpm_duration, 1.0)
+        for sk in self._skill_ids:
+            cap = self._skill_capacity.get(sk, 1.0)
+            total = sum(
+                self._activity_demand[a].get(sk, 0.0) * a.returnDuration()
+                for a in self._activities
+            )
+            loads[sk] = total / max(cap * denom, 1e-9)
+        return sorted(self._skill_ids, key=lambda s: loads[s], reverse=True)
+
+    def _randomize_weights(self) -> None:
+        """Pick a random resource-weight vector from the paper's weight sets."""
+        ranked = self._rank_resources()
+        wset = random.choice(_WEIGHT_SETS)
+        self._resource_weights: Dict[str, float] = {}
+        for i, sk in enumerate(ranked):
+            self._resource_weights[sk] = wset[i] if i < len(wset) else wset[-1]
+        # All unranked skills default to 1.0
+        for sk in self._skill_ids:
+            if sk not in self._resource_weights:
+                self._resource_weights[sk] = 1.0
+
+    # ------------------------------------------------------------------ #
+    # Chromosome ↔ activity list                                           #
+    # ------------------------------------------------------------------ #
+
+    def _chromosome_to_activities(self, order: List[int]) -> List[Any]:
+        return [self._activities[i] for i in order]
+
+    def _rule_to_order(self, rule: str) -> List[int]:
+        all_acts = list(self.pert.forwardDict.keys())
+        raw = self.pert.priority_calculation(all_acts, priority_rule=rule)
+        if raw and isinstance(raw[0], tuple):
+            ordered = [a for (a, _, _) in raw]
+        else:
+            ordered = list(raw)
+        return [self._act_to_idx[a] for a in ordered if a in self._act_to_idx]
+
+    def _make_individual(self, order: List[int], fitness: float = math.inf) -> Individual:
+        return {'order': list(order), 'fitness': fitness}
+
+    # ------------------------------------------------------------------ #
+    # Schedule decoding and timing reads                                   #
+    # ------------------------------------------------------------------ #
+
+    def _decode(self, order: List[int]) -> Dict[str, Any]:
+        acts = self._chromosome_to_activities(order)
+        return self.pert.calculateSerialScheduleWithResources(_ordered=acts)
+
+    def _decode_fitness(self, order: List[int]) -> float:
+        return self._decode(order)['scheduled_duration'] - 2
+
+    def _get_schedule_times(self) -> Dict[Any, Tuple[float, float]]:
+        """
+        Read start/end times (float hours from project start) for all activities.
+
+        Must be called immediately after a SGS decode, before the next call.
+        """
+        ps = self.pert.startTime
+        times: Dict[Any, Tuple[float, float]] = {}
+        for a in self._activities:
+            st = getattr(a, 'startTime', None)
+            et = getattr(a, 'endTime', None)
+            if st is not None and ps is not None:
+                s_h = (st - ps).total_seconds() / 3600.0
+                if et is not None:
+                    e_h = (et - ps).total_seconds() / 3600.0
+                else:
+                    e_h = s_h + a.returnDuration()
+                times[a] = (s_h, e_h)
+            else:
+                times[a] = (0.0, a.returnDuration())
+        return times
+
+    def _order_from_schedule(self, times: Dict[Any, Tuple[float, float]]) -> List[int]:
+        """Derive a precedence-feasible activity order from start times."""
+        sorted_acts = sorted(
+            self._activities,
+            key=lambda a: (times.get(a, (0.0, 0.0))[0], self._topo_idx.get(a, 0))
+        )
+        return [self._act_to_idx[a] for a in sorted_acts]
+
+    # ------------------------------------------------------------------ #
+    # Forward-Backward Improvement (FBI)                                   #
+    # ------------------------------------------------------------------ #
+
+    def _fbi(self, order: List[int]) -> Tuple[float, List[int]]:
+        """
+        Three-pass forward-backward-forward improvement.
+
+        Returns the best (fitness, order) across the three schedules.
+        Each pass counts as one evaluation toward lambda_max.
+        """
+        # Pass 1: forward
+        out1 = self._decode(order)
+        f1 = out1['scheduled_duration'] - 2
+        t1 = self._get_schedule_times()
+        o1 = self._order_from_schedule(t1)
+
+        # Pass 2: backward (reverse order → SGS pushes activities as late as possible)
+        out2 = self._decode(list(reversed(o1)))
+        f2 = out2['scheduled_duration'] - 2
+        t2 = self._get_schedule_times()
+        o2 = self._order_from_schedule(t2)
+
+        # Pass 3: forward again from backward-adjusted order
+        out3 = self._decode(o2)
+        f3 = out3['scheduled_duration'] - 2
+        t3 = self._get_schedule_times()
+        o3 = self._order_from_schedule(t3)
+
+        candidates = [(f1, o1), (f2, o2), (f3, o3)]
+        best_f, best_o = min(candidates, key=lambda x: x[0])
+        return best_f, best_o
+
+    def _evaluate_with_fbi(self, order: List[int]) -> Individual:
+        fitness, best_order = self._fbi(order)
+        return self._make_individual(best_order, fitness)
+
+    def _evaluate_no_fbi(self, order: List[int]) -> Individual:
+        fitness = self._decode_fitness(order)
+        return self._make_individual(order, fitness)
+
+    # ------------------------------------------------------------------ #
+    # Dense genes — DenseActivities(S, R) → Θ                             #
+    # ------------------------------------------------------------------ #
+
+    def _weighted_residual(
+        self,
+        active_acts: List[Any],
+    ) -> float:
+        """
+        Compute v_t = sum_k (R_k - sum_{j∈J(t)} r_jk) * w_k / R_k
+
+        Returns a value in [0, K] where 0 = fully utilised, K = completely idle.
+        """
+        if not self._skill_ids:
+            # Fallback: proportion of activities running (pseudo-utilisation)
+            n_total = max(1, len(self._activities))
+            return max(0.0, 1.0 - len(active_acts) / n_total)
+
+        v = 0.0
+        for sk in self._skill_ids:
+            cap = self._skill_capacity.get(sk, 1.0)
+            if cap <= 0:
+                continue
+            used = sum(self._activity_demand[a].get(sk, 0.0) for a in active_acts)
+            residual = max(0.0, cap - used)
+            w = self._resource_weights.get(sk, 1.0)
+            v += residual * w / cap
+        return v
+
+    def _dense_activities(
+        self, order: List[int], times: Dict[Any, Tuple[float, float]]
+    ) -> List[FrozenSet[Any]]:
+        """
+        Identify dense gene activity sets from a schedule.
+
+        Returns a list of frozensets, each being a non-overlapping dense gene.
+        Ordered by v_t (best first).
+        """
+        # Collect all event times
+        events: Set[float] = set()
+        for a in self._activities:
+            s, e = times.get(a, (0.0, 0.0))
+            if e > s:
+                events.add(s)
+                events.add(e)
+        if not events:
+            return []
+
+        sorted_events = sorted(events)
+        # Build (interval_start, active_set, v_t) for each interval
+        dense_candidates: List[Tuple[float, FrozenSet[Any], float]] = []
+        for i in range(len(sorted_events) - 1):
+            t_mid = (sorted_events[i] + sorted_events[i + 1]) / 2.0
+            active = [
+                a for a in self._activities
+                if times.get(a, (0.0, 0.0))[0] <= t_mid < times.get(a, (0.0, 0.0))[1]
+            ]
+            if not active:
+                continue
+            v = self._weighted_residual(active)
+            if v < self.resource_threshold:
+                dense_candidates.append((sorted_events[i], frozenset(active), v))
+
+        if not dense_candidates:
+            return []
+
+        # Overlap resolution: keep non-overlapping dense genes (lowest v_t wins)
+        dense_candidates.sort(key=lambda x: x[2])  # sort by v_t ascending
+        result: List[FrozenSet[Any]] = []
+        covered: Set[Any] = set()
+        for _t, gene, _v in dense_candidates:
+            new_acts = gene - covered
+            if new_acts:
+                result.append(frozenset(new_acts))
+                covered |= gene
+        return result
+
+    # ------------------------------------------------------------------ #
+    # Crossover A — dense-gene greedy merge                                #
+    # ------------------------------------------------------------------ #
+
+    def _crossover_A(self, p1: Individual, p2: Individual) -> Individual:
+        """
+        Algorithm: Crossover A (dense gene greedy merge).
+
+        Decode both parents, collect dense genes with their v_t weights,
+        greedily add activities from the parent chromosome containing the
+        best (lowest v_t) dense gene, skipping already-added activities,
+        then fill remainder from the shorter-duration parent.
+        """
+        out1 = self._decode(p1['order']); t1 = self._get_schedule_times()
+        genes1 = self._dense_activities(p1['order'], t1)
+
+        out2 = self._decode(p2['order']); t2 = self._get_schedule_times()
+        genes2 = self._dense_activities(p2['order'], t2)
+
+        # Build a merged gene list (activity set, parent index, v_t)
+        # Recompute v_t for each gene
+        merged: List[Tuple[FrozenSet[Any], int, float]] = []
+        for g in genes1:
+            active = list(g)
+            v = self._weighted_residual(active)
+            merged.append((g, 1, v))
+        for g in genes2:
+            active = list(g)
+            v = self._weighted_residual(active)
+            merged.append((g, 2, v))
+        merged.sort(key=lambda x: x[2])  # best (lowest) first
+
+        acts1 = self._chromosome_to_activities(p1['order'])
+        acts2 = self._chromosome_to_activities(p2['order'])
+
+        added: Set[int] = set()
+        child_acts: List[Any] = []
+
+        for gene, parent_idx, _v in merged:
+            parent_list = acts1 if parent_idx == 1 else acts2
+            for a in parent_list:
+                idx = self._act_to_idx[a]
+                if a in gene and idx not in added:
+                    child_acts.append(a)
+                    added.add(idx)
+
+        # Fill remainder from shorter-duration parent
+        shorter = acts1 if out1.get('scheduled_duration', math.inf) <= out2.get('scheduled_duration', math.inf) else acts2
+        for a in shorter:
+            idx = self._act_to_idx[a]
+            if idx not in added:
+                child_acts.append(a)
+                added.add(idx)
+
+        # Repair precedence
+        child_order = [self._act_to_idx[a] for a in child_acts if a in self._act_to_idx]
+        child_order = self._repair(child_order)
+        return self._evaluate_with_fbi(child_order)
+
+    # ------------------------------------------------------------------ #
+    # Crossover B — dense-gene network swap                                #
+    # ------------------------------------------------------------------ #
+
+    def _build_schedule_graph(
+        self, times: Dict[Any, Tuple[float, float]], tol: float = 0.5
+    ) -> Dict[Any, List[Any]]:
+        """
+        Build G_S: arcs (i,j) where c_i ≈ s_j (finish-start tight) AND (i,j)∈A.
+
+        Returns {activity: [immediate tight successors]}.
+        """
+        gs: Dict[Any, List[Any]] = {a: [] for a in self._activities}
+        for u, succs in self.pert.forwardDict.items():
+            if u not in times:
+                continue
+            _, cu = times[u]
+            for v in succs:
+                if v not in times:
+                    continue
+                sv, _ = times[v]
+                if abs(cu - sv) < tol:
+                    gs[u].append(v)
+        return gs
+
+    def _outgoing_network(
+        self, act: Any, gs: Dict[Any, List[Any]]
+    ) -> Set[Any]:
+        """BFS in G_S from act following outgoing arcs."""
+        visited: Set[Any] = set()
+        q: deque = deque([act])
+        while q:
+            node = q.popleft()
+            if node in visited:
+                continue
+            visited.add(node)
+            for succ in gs.get(node, []):
+                if succ not in visited:
+                    q.append(succ)
+        return visited
+
+    def _crossover_B(self, p1: Individual, p2: Individual) -> Individual:
+        """
+        Algorithm: Crossover B (network-based segment swap).
+
+        Selects the best dense gene from each parent, finds the outgoing/incoming
+        network in the OTHER parent's schedule graph, locates the segment span
+        in that parent's activity list, and swaps it in.
+        """
+        out1 = self._decode(p1['order']); t1 = self._get_schedule_times()
+        genes1 = self._dense_activities(p1['order'], t1)
+        gs1 = self._build_schedule_graph(t1)
+
+        out2 = self._decode(p2['order']); t2 = self._get_schedule_times()
+        genes2 = self._dense_activities(p2['order'], t2)
+        gs2 = self._build_schedule_graph(t2)
+
+        acts1 = self._chromosome_to_activities(p1['order'])
+        acts2 = self._chromosome_to_activities(p2['order'])
+
+        if not genes1 or not genes2:
+            # Fall back to Crossover A when no dense genes found
+            return self._crossover_A(p1, p2)
+
+        # Select best dense gene from each parent
+        best_g1 = genes1[0]
+        best_g2 = genes2[0]
+
+        # For gene from parent1, find its network in parent2's schedule graph
+        network_in_p2: Set[Any] = set()
+        for a in best_g1:
+            network_in_p2 |= self._outgoing_network(a, gs2)
+
+        # Find span (leftmost..rightmost) in parent2's list
+        pos2 = {a: i for i, a in enumerate(acts2)}
+        span_positions = [pos2[a] for a in network_in_p2 if a in pos2]
+        if not span_positions:
+            return self._crossover_A(p1, p2)
+
+        lo2, hi2 = min(span_positions), max(span_positions)
+        segment = acts2[lo2: hi2 + 1]
+
+        # Build child: acts1 with segment from acts2 inserted at correct location
+        seg_set = {self._act_to_idx[a] for a in segment if a in self._act_to_idx}
+        # Find corresponding span in acts1
+        pos1 = {a: i for i, a in enumerate(acts1)}
+        span1 = [pos1[a] for a in network_in_p2 if a in pos1]
+        ins = min(span1) if span1 else len(acts1) // 2
+
+        child_acts = [a for a in acts1 if self._act_to_idx[a] not in seg_set]
+        # Insert segment at position (clamped)
+        ins = min(ins, len(child_acts))
+        for j, a in enumerate(segment):
+            if a in self._act_to_idx:
+                child_acts.insert(ins + j, a)
+
+        child_order = [self._act_to_idx[a] for a in child_acts if a in self._act_to_idx]
+        # Ensure all activities present
+        present = set(child_order)
+        child_order += [i for i in range(self._n) if i not in present]
+        child_order = self._repair(child_order)
+        return self._evaluate_with_fbi(child_order)
+
+    # ------------------------------------------------------------------ #
+    # Mutation — two-phase swap + insertion                                #
+    # ------------------------------------------------------------------ #
+
+    def _mutate(self, ind: Individual) -> Individual:
+        """
+        Two-phase mutation:
+        Phase 1 — swap two random non-dummy activities (if precedence allows).
+        Phase 2 — insert a random activity into its feasible window.
+        FBI applied once at the end.
+        """
+        order = list(ind['order'])
+        n = len(order)
+
+        non_dummy_pos = [
+            p for p in range(n)
+            if self._activities[order[p]] not in self._dummy_acts
+        ]
+        if len(non_dummy_pos) < 2:
+            return self._evaluate_with_fbi(order)
+
+        # Phase 1: swap if feasible
+        i, j = random.sample(non_dummy_pos, 2)
+        if i > j:
+            i, j = j, i
+        act_i = self._activities[order[i]]
+        act_j = self._activities[order[j]]
+        backward = self.pert.backwardDict
+        if (act_i not in backward.get(act_j, []) and
+                act_j not in backward.get(act_i, [])):
+            order[i], order[j] = order[j], order[i]
+
+        # Phase 2: insertion into feasible window
+        if len(non_dummy_pos) >= 1:
+            cur_pos = random.choice(non_dummy_pos)
+            act = self._activities[order[cur_pos]]
+            pos_of = {order[p]: p for p in range(n)}
+            preds = backward.get(act, [])
+            succs = self.pert.forwardDict.get(act, [])
+            lo = (max(pos_of[self._act_to_idx[pr]] for pr in preds
+                      if pr in self._act_to_idx and self._act_to_idx[pr] in pos_of) + 1
+                  if preds else 0)
+            hi = (min(pos_of[self._act_to_idx[sc]] for sc in succs
+                      if sc in self._act_to_idx and self._act_to_idx[sc] in pos_of) - 1
+                  if succs else n - 1)
+            if lo <= hi:
+                new_pos = random.randint(lo, hi)
+                if new_pos != cur_pos:
+                    gene = order.pop(cur_pos)
+                    order.insert(new_pos if new_pos < cur_pos else new_pos - 1, gene)
+
+        return self._evaluate_with_fbi(order)
+
+    # ------------------------------------------------------------------ #
+    # Precedence repair                                                    #
+    # ------------------------------------------------------------------ #
+
+    def _repair(self, order: List[int]) -> List[int]:
+        """Repair precedence feasibility via reorder_by_dependencies."""
+        acts = self._chromosome_to_activities(order)
+        ranked = [(a, i) for i, a in enumerate(acts)]
+        try:
+            repaired = self.pert.reorder_by_dependencies(ranked, self.pert.forwardDict)
+            return [self._act_to_idx[a] for a, _ in repaired if a in self._act_to_idx]
+        except Exception:
+            return order
+
+    # ------------------------------------------------------------------ #
+    # Initial population                                                   #
+    # ------------------------------------------------------------------ #
+
+    def _build_initial_population(self) -> List[Individual]:
+        """
+        Build initial population from priority rules + random fill.
+        No FBI applied (too expensive for initial population).
+        """
+        pop: List[Individual] = []
+        seed_info: Dict[str, float] = {}
+
+        for rule in PRIORITY_RULES:
+            if len(pop) >= self.pop_size:
+                break
+            try:
+                self.pert.priorities = None
+                order = self._rule_to_order(rule)
+                ind = self._evaluate_no_fbi(order)
+                pop.append(ind)
+                seed_info[rule] = ind['fitness']
+            except Exception as exc:
+                logger.warning("Skipping rule '%s': %s", rule, exc)
+
+        while len(pop) < self.pop_size:
+            try:
+                self.pert.priorities = None
+                order = self._rule_to_order('random')
+                pop.append(self._evaluate_no_fbi(order))
+            except Exception:
+                break
+
+        n_rand = len(pop) - len(seed_info)
+        if self.verbose and seed_info:
+            best_s = min(seed_info.values())
+            print(f"\nGANS initial population: {len(seed_info)} rule-seeded "
+                  f"+ {n_rand} random  |  best seeded = {best_s:.2f} h\n")
+            print(f"  {'Rule':<22} {'Fitness (h)':>12}")
+            print("  " + "-" * 36)
+            for r, f in seed_info.items():
+                print(f"  {r:<22} {f:>12.2f}")
+            print()
+        return pop
+
+    # ------------------------------------------------------------------ #
+    # Parent selection — probability-based scan (Section 5 of paper)      #
+    # ------------------------------------------------------------------ #
+
+    def _select_parents(
+        self, pop: List[Individual], p_select: float = 0.25
+    ) -> List[Individual]:
+        """
+        Scan population in non-decreasing fitness order; add each to Γ'
+        with probability p_select until parents_size reached or all scanned.
+        Guarantee at least the best individual is included.
+        """
+        sorted_pop = sorted(pop, key=lambda x: x['fitness'])
+        parents: List[Individual] = [sorted_pop[0]]  # always include best
+        for ind in sorted_pop[1:]:
+            if len(parents) >= self.parents_size:
+                break
+            if random.random() < p_select:
+                parents.append(ind)
+        return parents
+
+    # ------------------------------------------------------------------ #
+    # Neighbourhood NA — block reschedule                                  #
+    # ------------------------------------------------------------------ #
+
+    def _create_block(
+        self,
+        core_act: Any,
+        times: Dict[Any, Tuple[float, float]],
+        P: int,
+    ) -> List[Any]:
+        """
+        CreateBlock(j, S, P): collect P activities overlapping or near core_act.
+        """
+        s_j, e_j = times.get(core_act, (0.0, 0.0))
+        p_j = e_j - s_j  # duration in hours
+        others = [a for a in self._activities if a is not core_act]
+        random.shuffle(others)
+
+        block: List[Any] = [core_act]
+        b = 0.0
+        max_b = self._cpm_duration
+
+        while len(block) < P and b <= max_b:
+            added_this_round = False
+            for a in others:
+                if a in block:
+                    continue
+                s_i, e_i = times.get(a, (0.0, 0.0))
+                p_i = e_i - s_i
+                if s_j - p_i - b <= s_i <= s_j + p_j + b:
+                    block.append(a)
+                    if len(block) >= P:
+                        break
+                    added_this_round = True
+            if not added_this_round:
+                b += max(0.5, p_j / 4.0)
+
+        return block
+
+    def _na_neighbor(self, ind: Individual) -> Optional[Individual]:
+        """
+        Neighborhood NA: select core activity, extract block, reschedule it.
+
+        The block activities are removed from their current order positions and
+        re-inserted at their earliest feasible positions in the remaining list.
+        """
+        out = self._decode(ind['order'])
+        times = self._get_schedule_times()
+        order = self._order_from_schedule(times)
+
+        non_dummy = [a for a in self._activities if a not in self._dummy_acts]
+        if not non_dummy:
+            return None
+        core = random.choice(non_dummy)
+        block = self._create_block(core, times, self._block_size)
+
+        if not block:
+            self._empty_block_history.append(True)
+            return None
+        self._empty_block_history.append(False)
+
+        block_set = {self._act_to_idx[a] for a in block if a in self._act_to_idx}
+
+        # Residual list (non-block activities in their current order)
+        residual = [i for i in order if i not in block_set]
+
+        # Compute EST for each block activity from its predecessors' positions
+        # Insert block activities at their EST-derived positions in the residual
+        pos_residual = {idx: p for p, idx in enumerate(residual)}
+        for a in block:
+            if a not in self._act_to_idx:
+                continue
+            a_idx = self._act_to_idx[a]
+            preds = self.pert.backwardDict.get(a, [])
+            lo = (max(pos_residual.get(self._act_to_idx[pr], -1)
+                      for pr in preds
+                      if pr in self._act_to_idx) + 1
+                  if preds else 0)
+            lo = max(0, lo)
+            succs = self.pert.forwardDict.get(a, [])
+            hi = (min(pos_residual.get(self._act_to_idx[sc], len(residual))
+                      for sc in succs
+                      if sc in self._act_to_idx) - 1
+                  if succs else len(residual))
+            hi = min(max(lo, hi), len(residual))
+            ins = random.randint(lo, hi)
+            residual.insert(ins, a_idx)
+            # update position map
+            pos_residual = {idx: p for p, idx in enumerate(residual)}
+
+        child_order = self._repair(residual)
+        fitness, best_order = self._fbi(child_order)
+        return self._make_individual(best_order, fitness)
+
+    # ------------------------------------------------------------------ #
+    # Neighbourhood NB — split-list GRASP parallel SGS                    #
+    # ------------------------------------------------------------------ #
+
+    def _grasp_parallel_sgs(
+        self,
+        block_acts: List[Any],
+        used_resources: Dict[str, float],
+        n_restarts: int = 5,
+    ) -> List[Any]:
+        """
+        Greedy-randomized selection of one activity from the eligible set,
+        maximising weighted resource utilisation.
+
+        Returns a ordering of block_acts chosen by GRASP.
+        """
+        alpha = 3  # restricted candidate list size
+        scheduled: List[Any] = []
+        eligible = list(block_acts)
+
+        while eligible:
+            # Score each eligible activity by its weighted resource demand
+            scores = []
+            for a in eligible:
+                score = sum(
+                    self._resource_weights.get(sk, 1.0)
+                    * self._activity_demand[a].get(sk, 0.0)
+                    / max(self._skill_capacity.get(sk, 1.0), 1.0)
+                    for sk in self._skill_ids
+                ) if self._skill_ids else 1.0
+                # Penalise activities that would exceed remaining resource capacity
+                feasible = True
+                for sk in self._skill_ids:
+                    cap = self._skill_capacity.get(sk, math.inf)
+                    if used_resources.get(sk, 0.0) + self._activity_demand[a].get(sk, 0.0) > cap:
+                        feasible = False
+                        break
+                scores.append((score if feasible else -1.0, self._act_to_idx.get(a, 0), a))
+
+            scores.sort(key=lambda x: x[0], reverse=True)
+            rcl = [a for _, _idx, a in scores[:alpha] if scores[0][0] >= 0]
+            if not rcl:
+                rcl = [eligible[0]]
+
+            chosen = random.choice(rcl)
+            scheduled.append(chosen)
+            eligible.remove(chosen)
+            for sk in self._skill_ids:
+                used_resources[sk] = (
+                    used_resources.get(sk, 0.0)
+                    + self._activity_demand[chosen].get(sk, 0.0)
+                )
+
+        return scheduled
+
+    def _nb_neighbor(self, ind: Individual) -> Optional[Individual]:
+        """
+        Neighborhood NB: split list L = A1 | block | A2.
+
+        A1 scheduled with serial SGS; block with GRASP-parallel SGS; A2 appended.
+        """
+        order = list(ind['order'])
+        n = len(order)
+        non_dummy = [self._activities[i] for i in order
+                     if self._activities[i] not in self._dummy_acts]
+        if len(non_dummy) < 2:
+            return None
+
+        core = random.choice(non_dummy)
+        core_idx = order.index(self._act_to_idx[core])
+
+        # Decode for timing to build block
+        self._decode(order)
+        times = self._get_schedule_times()
+        block_acts = self._create_block(core, times, self._block_size)
+
+        # Exclude block members from the full order
+        block_idx_set = {self._act_to_idx[a] for a in block_acts if a in self._act_to_idx}
+
+        # Check: if any block member is a predecessor of core, skip
+        preds_of_core = set(self.pert.backwardDict.get(core, []))
+        if preds_of_core & set(block_acts):
+            return None
+
+        # Split at core position
+        a1_order = [i for i in order[:core_idx] if i not in block_idx_set]
+        a2_order = [i for i in order[core_idx + 1:] if i not in block_idx_set]
+
+        # Schedule A1 fragment via serial SGS on a1 activities
+        # GRASP the block
+        used: Dict[str, float] = {}  # approx resource usage (just for guidance)
+        grasp_order = self._grasp_parallel_sgs(block_acts, used, n_restarts=5)
+
+        # Assemble full child order: A1 + GRASP block + A2
+        grasp_indices = [self._act_to_idx[a] for a in grasp_order if a in self._act_to_idx]
+        child_order = a1_order + grasp_indices + a2_order
+
+        # Ensure every activity present exactly once
+        present = set(child_order)
+        child_order += [i for i in range(self._n) if i not in present]
+
+        child_order = self._repair(child_order)
+        fitness, best_order = self._fbi(child_order)
+        return self._make_individual(best_order, fitness)
+
+    # ------------------------------------------------------------------ #
+    # Adaptive block-size update                                           #
+    # ------------------------------------------------------------------ #
+
+    def _update_block_size(self) -> None:
+        """Increase P if most neighbors non-empty; decrease if mostly empty."""
+        window = 20
+        if len(self._empty_block_history) < window:
+            return
+        recent = self._empty_block_history[-window:]
+        empty_rate = sum(recent) / window
+        if empty_rate > 0.5 and self._block_size > 1:
+            self._block_size -= 1
+        elif empty_rate < 0.2 and self._block_size < max(10, self._n // 4):
+            self._block_size += 1
+        # Full reset if P dropped to 1
+        if self._block_size == 1:
+            self._block_size = self.block_size
+            self._randomize_weights()
+
+    # ------------------------------------------------------------------ #
+    # Instance classification (σ-based)                                   #
+    # ------------------------------------------------------------------ #
+
+    def _assign_subset_params(self, best_fitness: float) -> None:
+        """
+        Classify instance into subset {1, 2, 3} by σ and adapt
+        GA stall limit and NS steps accordingly.
+        """
+        cpm = max(self._cpm_duration, 1.0)
+        sigma = (best_fitness - cpm) / cpm
+        if sigma < self.sigma1:
+            subset, self.ga_stall_limit, self.ns_steps = 1, 80, 50
+        elif sigma <= self.sigma2:
+            subset, self.ga_stall_limit, self.ns_steps = 2, 50, 150
+        else:
+            subset, self.ga_stall_limit, self.ns_steps = 3, 20, 300
+        if self.verbose:
+            print(f"  σ = {sigma:.3f} → subset {subset} | "
+                  f"ga_stall={self.ga_stall_limit} | ns_steps={self.ns_steps}")
+
+    # ------------------------------------------------------------------ #
+    # Tabu list for NS                                                     #
+    # ------------------------------------------------------------------ #
+
+    def _tabu_key(self, ind: Individual) -> int:
+        """Sum of start times as tabu signature (Paper Section 6)."""
+        self._decode(ind['order'])
+        times = self._get_schedule_times()
+        return int(sum(s for s, _ in times.values()))
+
+    # ------------------------------------------------------------------ #
+    # Main optimisation loop                                               #
+    # ------------------------------------------------------------------ #
+
+    def run(self) -> Tuple[Individual, List[Dict]]:
+        """
+        Execute the GANS algorithm.
+
+        Returns
+        -------
+        best : Individual
+            Best individual found.
+        log : list of dict
+            Per-generation records with keys:
+            ``n_evals``, ``best``, ``event``, ``ga_stall``, ``n_ns_activations``.
+        """
+        # ── Initialisation ─────────────────────────────────────────────
+        pop = self._build_initial_population()
+        pop.sort(key=lambda x: x['fitness'])
+        n_evals = len(pop)
+
+        best = self._make_individual(pop[0]['order'], pop[0]['fitness'])
+        self._assign_subset_params(best['fitness'])
+
+        ga_stall = 0
+        n_ns_activations = 0
+        p_parent = 0.25
+        log: List[Dict] = []
+
+        def _log(event: str = '') -> None:
+            log.append({
+                'n_evals': n_evals,
+                'best': best['fitness'],
+                'event': event,
+                'ga_stall': ga_stall,
+                'n_ns_activations': n_ns_activations,
+            })
+
+        _log('init')
+        if self.verbose:
+            print(f"{'n_evals':>8}  {'best (h)':>10}  {'event':<16}")
+            print("-" * 40)
+            print(f"{n_evals:>8}  {best['fitness']:>10.2f}  {'init':<16}")
+
+        # ── Main loop ──────────────────────────────────────────────────
+        gen = 0
+        while n_evals < self.lambda_max:
+            gen += 1
+            parents = self._select_parents(pop, p_parent)
+            if len(parents) < 2:
+                parents = sorted(pop, key=lambda x: x['fitness'])[:2]
+
+            # Produce offspring (one crossing per gen, per paper)
+            p1 = random.choice(parents)
+            p2 = random.choice(parents)
+            cx = random.choice([self._crossover_A, self._crossover_B])
+            child = cx(p1, p2)
+            n_evals += 3  # FBI = 3 SGS calls
+
+            # Apply mutation only if crossing didn't improve
+            if child['fitness'] >= min(p1['fitness'], p2['fitness']):
+                mutant = self._mutate(child)
+                n_evals += 3
+                if mutant['fitness'] <= child['fitness']:
+                    child = mutant
+
+            # Update best
+            improved = child['fitness'] < best['fitness']
+            if improved:
+                best = self._make_individual(child['order'], child['fitness'])
+                ga_stall = 0
+            else:
+                ga_stall += 1
+
+            # Tournament update: add child, remove worst
+            pop.append(child)
+            pop.sort(key=lambda x: x['fitness'])
+            pop = pop[:self.pop_size]
+
+            # ── NS activation ─────────────────────────────────────────
+            if ga_stall >= self.ga_stall_limit and n_evals < self.lambda_max:
+                n_ns_activations += 1
+                event = f"NS#{n_ns_activations}"
+
+                # Start NS from current best individual
+                ns_current = self._make_individual(best['order'], best['fitness'])
+                tabu: List[int] = []
+                tabu_key_current = self._tabu_key(ns_current)
+
+                for _step in range(self.ns_steps):
+                    if n_evals >= self.lambda_max:
+                        break
+                    ns_type = random.choice(['NA', 'NB'])
+                    neighbor = (
+                        self._na_neighbor(ns_current)
+                        if ns_type == 'NA'
+                        else self._nb_neighbor(ns_current)
+                    )
+                    n_evals += 3  # FBI inside neighbor
+
+                    if neighbor is None:
+                        continue
+
+                    tk = self._tabu_key(neighbor)
+                    n_evals += 1
+                    if tk in tabu:
+                        continue  # skip tabu
+
+                    if neighbor['fitness'] < ns_current['fitness']:
+                        ns_current = neighbor
+                        tabu.append(tabu_key_current)
+                        if len(tabu) > 10:
+                            tabu.pop(0)
+                        tabu_key_current = tk
+
+                    if ns_current['fitness'] < best['fitness']:
+                        best = self._make_individual(ns_current['order'], ns_current['fitness'])
+
+                    self._update_block_size()
+
+                # Reinject best into population; restart GA
+                pop[0] = self._make_individual(best['order'], best['fitness'])
+                ga_stall = 0
+                self._randomize_weights()
+
+                if self.verbose:
+                    print(f"{n_evals:>8}  {best['fitness']:>10.2f}  {event:<16}")
+                _log(event)
+                continue
+
+            if self.verbose and (gen % 50 == 0 or improved):
+                tag = "*" if improved else ""
+                print(f"{n_evals:>8}  {best['fitness']:>10.2f}  {tag:<16}")
+
+            _log()
+
+        logger.info(
+            "GANS finished | best = %.2f h | evals = %d | NS activations = %d",
+            best['fitness'], n_evals, n_ns_activations,
+        )
+        return best, log
+
+    # ------------------------------------------------------------------ #
+    # Result helpers                                                       #
+    # ------------------------------------------------------------------ #
+
+    def get_best_schedule(self, best: Individual) -> Dict:
+        """Re-run SGS with the best activity order; leaves pert in best state."""
+        acts = self._chromosome_to_activities(best['order'])
+        return self.pert.calculateSerialScheduleWithResources(_ordered=acts)
+
+    def get_best_activity_list(self, best: Individual) -> List[str]:
+        """Return best scheduling order as a list of task names."""
+        return [self._activities[i].returnName() for i in best['order']]
+
+    def get_convergence_summary(self, log: List[Dict]) -> Dict:
+        """
+        Concise convergence summary.
+
+        Returns dict with keys:
+            ``n_evals``, ``best_duration``, ``initial_best``,
+            ``improvement``, ``n_ns_activations``, ``final_stall``.
+        """
+        if not log:
+            return {}
+        return {
+            'n_evals': log[-1]['n_evals'],
+            'best_duration': log[-1]['best'],
+            'initial_best': log[0]['best'],
+            'improvement': log[0]['best'] - log[-1]['best'],
+            'n_ns_activations': log[-1]['n_ns_activations'],
+            'final_stall': log[-1]['ga_stall'],
+        }

--- a/src/CPM/gans_test.py
+++ b/src/CPM/gans_test.py
@@ -1,0 +1,260 @@
+"""
+gans_test.py — Combined benchmark for GA, ALNS, and GANS on PSPLIB instances
+
+Runs three RCPSP metaheuristics on each benchmark JSON (j30, j60, j90, j120):
+  1. Genetic Algorithm (``ga.py``)
+  2. Adaptive Large Neighbourhood Search (``rcpsp_alns.py``)
+  3. Hybrid GA + Neighbourhood Search (``gans.py``)
+
+Prints a per-case comparison report and a unified summary table.
+
+This script subsumes ``alns_test.py`` — all four benchmark cases and the
+same ALNS hyper-parameters are reproduced here.
+
+References
+----------
+Kolisch, R. and Hartmann, S. (1999). Heuristic Algorithms for Solving the
+Resource-Constrained Project Scheduling Problem.
+
+Wouda, N.A., and L. Lan (2023). ALNS: a Python implementation.
+Journal of Open Source Software, 8(81): 5028.
+
+Goncharov, E.N. (2025). A hybrid heuristic algorithm for the
+resource-constrained project scheduling problem. arXiv:2502.18330v2.
+
+Usage (from the src/CPM directory):
+    python gans_test.py
+
+Or from the repo root:
+    python -m src.CPM.gans_test
+"""
+
+import sys
+import logging
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src import Pert  # noqa: E402
+from src.CPM.ga import RCPSPGeneticAlgorithm  # noqa: E402
+from src.CPM.rcpsp_alns import RCPSPAdaptiveLNS, SEED_PRIORITY_RULES  # noqa: E402
+from src.CPM.gans import RCPSPHybridGANS, PRIORITY_RULES  # noqa: E402
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+SCHEMA = Path(__file__).parent / "outage_schema.json"
+
+CASES = [
+    ("j30",  "j301_1.json"),
+    ("j60",  "j601_1.json"),
+    ("j90",  "j901_1.json"),
+    ("j120", "j1201_1.json"),
+]
+
+# Combined rule list for serial-SGS baseline
+_ALL_RULES = list(dict.fromkeys(PRIORITY_RULES + SEED_PRIORITY_RULES))
+
+
+def _compute_serial_baseline(pert) -> dict:
+    """Run serial SGS for every priority rule; return {rule: duration} dict."""
+    durations = {}
+    for rule in _ALL_RULES:
+        try:
+            pert.priorities = None
+            out = pert.calculateSerialScheduleWithResources(priority_rule=rule)
+            durations[rule] = out['scheduled_duration'] - 2
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Rule '%s' skipped: %s", rule, exc)
+    return durations
+
+
+def run_case(
+    case_name: str,
+    json_file: str,
+    # GA params
+    ga_pop_size: int = 30,
+    ga_n_gen: int = 500,
+    ga_cxpb: float = 0.8,
+    ga_mutpb: float = 0.1,
+    ga_crossover: str = 'two_point',
+    ga_mutation: str = 'adjacent_swap',
+    # ALNS params
+    alns_n_iter: int = 2000,
+    alns_destroy_fraction: float = 0.25,
+    alns_theta: float = 0.8,
+    alns_seg_length: int = 100,
+    alns_accept: str = 'hill_climbing',
+    # GANS params
+    gans_pop_size: int = 60,
+    gans_lambda_max: int = 5000,
+    gans_ga_stall_limit: int = 50,
+    gans_ns_steps: int = 200,
+    gans_block_size: int = 6,
+    gans_resource_threshold: float = 0.75,
+    # Shared
+    seed: int = 42,
+    verbose: bool = True,
+) -> dict:
+    """
+    Load one PSPLIB benchmark instance and run GA, ALNS, and GANS on it.
+
+    Returns a summary dict with per-algorithm best durations.
+    """
+    json_path = Path(__file__).parent / json_file
+
+    print("=" * 70)
+    print(f"Case: {case_name}  ({json_file})")
+    print("=" * 70)
+
+    pert = Pert.from_json_file(str(json_path), schema_path=str(SCHEMA))
+    pert.generateInfo()
+
+    cpm_duration = pert.getProjectDuration()
+    n_activities = len(pert.infoDict)
+
+    print(f"Activities      : {n_activities}")
+    print(f"CPM duration    : {cpm_duration:.2f} h  (unconstrained)")
+    print()
+
+    # ── Priority-rule baseline ──────────────────────────────────────────────
+    serial_durations = _compute_serial_baseline(pert)
+    best_rule = min(serial_durations.values(), default=float('inf'))
+
+    if verbose:
+        print("Priority rule baseline durations (serial SGS):")
+        print(f"  {'Rule':<22} {'Serial (h)':>12}")
+        print("  " + "-" * 36)
+        for rule in _ALL_RULES:
+            s = serial_durations.get(rule, float('nan'))
+            print(f"  {rule:<22} {s:>12.2f}")
+        print()
+
+    # ── GA ──────────────────────────────────────────────────────────────────
+    print(f"Running GA (pop={ga_pop_size}, n_gen={ga_n_gen}, "
+          f"cx={ga_crossover}, mut={ga_mutation})...")
+    ga = RCPSPGeneticAlgorithm(
+        pert,
+        pop_size=ga_pop_size,
+        n_gen=ga_n_gen,
+        cxpb=ga_cxpb,
+        mutpb=ga_mutpb,
+        seed=seed,
+        verbose=False,
+        crossover=ga_crossover,
+        mutation=ga_mutation,
+    )
+    ga_hof, _ = ga.run()
+    best_ga = ga.get_best_schedule(ga_hof)['scheduled_duration'] - 2
+    print(f"  GA best: {best_ga:.2f} h")
+    print()
+
+    # ── ALNS ────────────────────────────────────────────────────────────────
+    print(f"Running ALNS (n_iter={alns_n_iter}, destroy={alns_destroy_fraction}, "
+          f"accept={alns_accept})...")
+    alns = RCPSPAdaptiveLNS(
+        pert,
+        n_iter=alns_n_iter,
+        destroy_fraction=alns_destroy_fraction,
+        theta=alns_theta,
+        seg_length=alns_seg_length,
+        seed=seed,
+        accept=alns_accept,
+        verbose=False,
+    )
+    alns_best_state, alns_log = alns.run()
+    best_alns = alns_log['best_duration']
+    print(f"  ALNS best: {best_alns:.2f} h")
+    print()
+
+    # ── GANS ────────────────────────────────────────────────────────────────
+    print(f"Running GANS (pop={gans_pop_size}, λ_max={gans_lambda_max}, "
+          f"stall={gans_ga_stall_limit}, ns_steps={gans_ns_steps})...")
+    gans = RCPSPHybridGANS(
+        pert,
+        pop_size=gans_pop_size,
+        lambda_max=gans_lambda_max,
+        ga_stall_limit=gans_ga_stall_limit,
+        ns_steps=gans_ns_steps,
+        block_size=gans_block_size,
+        resource_threshold=gans_resource_threshold,
+        seed=seed,
+        verbose=verbose,
+    )
+    gans_best, gans_log = gans.run()
+    best_gans = gans_best['fitness']
+    gans_summary = gans.get_convergence_summary(gans_log)
+
+    print()
+    print(f"{'─' * 60}")
+    print(f"  CPM (unconstrained)           : {cpm_duration:.2f} h")
+    print(f"  Best priority-rule (serial)   : {best_rule:.2f} h")
+    print(f"  GA best                       : {best_ga:.2f} h  "
+          f"(Δ {best_rule - best_ga:+.2f})")
+    print(f"  ALNS best                     : {best_alns:.2f} h  "
+          f"(Δ {best_rule - best_alns:+.2f})")
+    print(f"  GANS best                     : {best_gans:.2f} h  "
+          f"(Δ {best_rule - best_gans:+.2f})")
+    print(f"  GANS initial best             : {gans_summary['initial_best']:.2f} h")
+    print(f"  GANS improvement              : {gans_summary['improvement']:.2f} h")
+    print(f"  GANS NS activations           : {gans_summary['n_ns_activations']}")
+    print(f"{'─' * 60}")
+    print(f"  GANS best list (first 10)     : "
+          f"{gans.get_best_activity_list(gans_best)[:10]}")
+    print()
+
+    return {
+        'case': case_name,
+        'n_activities': n_activities,
+        'cpm_duration': cpm_duration,
+        'best_rule': best_rule,
+        'best_ga': best_ga,
+        'best_alns': best_alns,
+        'best_gans': best_gans,
+        'gans_n_ns': gans_summary['n_ns_activations'],
+    }
+
+
+def main() -> None:
+    """Run all benchmark cases and print a unified comparison table."""
+    results = []
+    for case_name, json_file in CASES:
+        r = run_case(
+            case_name=case_name,
+            json_file=json_file,
+            ga_pop_size=30,
+            ga_n_gen=500,
+            alns_n_iter=2000,
+            gans_pop_size=60,
+            gans_lambda_max=5000,
+            gans_ga_stall_limit=50,
+            gans_ns_steps=200,
+            seed=42,
+            verbose=True,
+        )
+        results.append(r)
+
+    print("\n" + "=" * 90)
+    print("SUMMARY — GA / ALNS / GANS  (PSPLIB j30–j120, serial SGS decoder)")
+    print("=" * 90)
+    print(
+        f"  {'Case':<8} {'N':>6} {'CPM (h)':>9} "
+        f"{'BestRule':>9} {'GA':>8} {'ALNS':>8} {'GANS':>8} "
+        f"{'Δ GA':>7} {'Δ ALNS':>7} {'Δ GANS':>7} {'NS#':>5}"
+    )
+    print("  " + "-" * 82)
+    for r in results:
+        print(
+            f"  {r['case']:<8} {r['n_activities']:>6} {r['cpm_duration']:>9.2f} "
+            f"{r['best_rule']:>9.2f} {r['best_ga']:>8.2f} {r['best_alns']:>8.2f} "
+            f"{r['best_gans']:>8.2f} "
+            f"{r['best_rule'] - r['best_ga']:>7.2f} "
+            f"{r['best_rule'] - r['best_alns']:>7.2f} "
+            f"{r['best_rule'] - r['best_gans']:>7.2f} "
+            f"{r['gans_n_ns']:>5}"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CPM/gans_test_hard.py
+++ b/src/CPM/gans_test_hard.py
@@ -1,0 +1,244 @@
+"""
+gans_test_hard.py — Hard-instance integration test for the RCPSP GANS solver
+
+Runs the hybrid GA + neighbourhood search algorithm on a selected set of
+difficult PSPLIB j120 benchmark instances and prints:
+  - Best GANS duration
+  - Best-known PSPLIB duration
+  - Gap between GANS and the best-known solution
+
+Usage (from the src/CPM directory):
+    python gans_test_hard.py
+
+Or from the repo root:
+    python -m src.CPM.gans_test_hard
+"""
+
+import sys
+import logging
+import json
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src import Pert  # noqa: E402
+from src.CPM.gans import RCPSPHybridGANS, PRIORITY_RULES  # noqa: E402
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+SCHEMA = Path(__file__).parent / "outage_schema.json"
+BEST_RESULTS_PATH = Path(__file__).parent / "benchmarks" / "best_results.json"
+
+CASES = [
+    ("j12051_6",  "benchmarks/PSPLIB_Json/j120/j12051_6.json"),
+    ("j12031_10", "benchmarks/PSPLIB_Json/j120/j12031_10.json"),
+    ("j12036_6",  "benchmarks/PSPLIB_Json/j120/j12036_6.json"),
+    ("j12056_7",  "benchmarks/PSPLIB_Json/j120/j12056_7.json"),
+    ("j12051_5",  "benchmarks/PSPLIB_Json/j120/j12051_5.json"),
+    ("j12056_1",  "benchmarks/PSPLIB_Json/j120/j12056_1.json"),
+    ("j12026_10", "benchmarks/PSPLIB_Json/j120/j12026_10.json"),
+    ("j12051_7",  "benchmarks/PSPLIB_Json/j120/j12051_7.json"),
+    ("j12056_5",  "benchmarks/PSPLIB_Json/j120/j12056_5.json"),
+    ("j12056_9",  "benchmarks/PSPLIB_Json/j120/j12056_9.json"),
+]
+
+# ==========================================================================================
+# SUMMARY — GANS HARD CASES (PSPLIB j120, best-known comparison)
+# ==========================================================================================
+#   Case              N    CPM (h)   Best Serial  Best Parallel    Best GANS   Best Known   GANS-BK    Δ (h)   NS#
+#   --------------------------------------------------------------------------------------------------------------------
+#   j12051_6        122     106.00        262.00         256.00       230.00       214.00     16.00    26.00     4
+#   j12031_10       122      92.00        285.00         266.00       250.00       225.00     25.00    16.00     4
+#   j12036_6        122     103.00        271.00         263.00       253.00       224.00     29.00    10.00     4
+#   j12056_7        122     119.00        336.00         320.00       314.00       282.00     32.00     6.00     4
+#   j12051_5        122     104.00        280.00         266.00       254.00       229.00     25.00    12.00     4
+#   j12056_1        122      97.00        279.00         273.00       263.00       236.00     27.00    10.00     4
+#   j12026_10       122     124.00        224.00         219.00       187.00       183.00      4.00    32.00     4
+#   j12051_7        122      93.00        254.00         247.00       218.00       211.00      7.00    29.00     4
+#   j12056_5        122     119.00        338.00         315.00       305.00       279.00     26.00    10.00     4
+#   j12056_9        122     103.00        341.00         325.00       321.00       287.00     34.00     4.00     4
+
+
+def load_best_known_results() -> dict[str, float]:
+    """Load PSPLIB best-known results keyed by `<instance>.sm`."""
+    with BEST_RESULTS_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_best_known_result(best_results: dict[str, float], json_file: str) -> float | None:
+    """Resolve the benchmark JSON filename to the corresponding PSPLIB result key."""
+    instance_key = f"{Path(json_file).stem}.sm"
+    return best_results.get(instance_key)
+
+
+def run_gans_case(
+    case_name: str,
+    json_file: str,
+    best_known: float | None,
+    pop_size: int = 60,
+    lambda_max: int = 5000,
+    ga_stall_limit: int = 50,
+    ns_steps: int = 200,
+    block_size: int = 6,
+    resource_threshold: float = 0.75,
+    seed: int = 42,
+    verbose: bool = True,
+) -> dict:
+    """
+    Run GANS on a single hard PSPLIB benchmark case.
+
+    Returns
+    -------
+    dict with keys:
+        case, n_activities, cpm_duration, best_serial_seed, best_parallel_seed,
+        best_gans, best_known, gans_vs_best_known, improvement, gans_n_ns
+    """
+    json_path = Path(__file__).parent / json_file
+
+    print("=" * 70)
+    print(f"Case: {case_name}  ({json_file})")
+    print("=" * 70)
+
+    pert = Pert.from_json_file(str(json_path), schema_path=str(SCHEMA))
+    pert.generateInfo()
+
+    cpm_duration = pert.getProjectDuration()
+    n_activities = len(pert.infoDict)
+
+    print(f"Activities      : {n_activities}")
+    print(f"CPM duration    : {cpm_duration:.2f} h  (unconstrained)")
+    print()
+
+    # ── Baseline: best duration from all named priority rules ─────────────────
+    serial_durations = {}
+    parallel_durations = {}
+
+    for rule in PRIORITY_RULES:
+        try:
+            pert.priorities = None
+            s_out = pert.calculateSerialScheduleWithResources(priority_rule=rule)
+            serial_durations[rule] = s_out['scheduled_duration'] - 2
+
+            pert.priorities = None
+            p_out = pert.calculateScheduleWithResources(
+                sgs='max_use_res_ranked', priority_rule=rule
+            )
+            parallel_durations[rule] = p_out['scheduled_duration'] - 2
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Rule '%s' skipped in baseline: %s", rule, exc)
+
+    best_serial = (
+        min(serial_durations.values()) if serial_durations else float('inf')
+    )
+    best_parallel = (
+        min(parallel_durations.values()) if parallel_durations else float('inf')
+    )
+    best_rule_overall = min(best_serial, best_parallel)
+
+    print(
+        f"Running GANS (pop={pop_size}, λ_max={lambda_max}, "
+        f"stall={ga_stall_limit}, ns_steps={ns_steps})..."
+    )
+    gans = RCPSPHybridGANS(
+        pert,
+        pop_size=pop_size,
+        lambda_max=lambda_max,
+        ga_stall_limit=ga_stall_limit,
+        ns_steps=ns_steps,
+        block_size=block_size,
+        resource_threshold=resource_threshold,
+        seed=seed,
+        verbose=verbose,
+    )
+    gans_best, gans_log = gans.run()
+    best_gans = gans_best['fitness']
+    gans_summary = gans.get_convergence_summary(gans_log)
+    gans_vs_best_known = (
+        best_gans - best_known if best_known is not None else float('nan')
+    )
+
+    print()
+    print(f"{'─' * 60}")
+    print(f"  CPM duration (unconstrained)  : {cpm_duration:.2f} h")
+    print(f"  Best serial SGS  (all rules)  : {best_serial:.2f} h")
+    print(f"  Best parallel SGS (all rules) : {best_parallel:.2f} h")
+    print(f"  Best GANS duration            : {best_gans:.2f} h")
+    print(f"  Improvement over best rule    : {best_rule_overall - best_gans:.2f} h")
+    if best_known is not None:
+        print(f"  Best-known solution           : {best_known:.2f} h")
+        print(f"  GANS - best-known            : {gans_vs_best_known:.2f} h")
+    else:
+        print("  Best-known solution           : n/a")
+        print("  GANS - best-known            : n/a")
+    print(f"  GANS initial best             : {gans_summary['initial_best']:.2f} h")
+    print(f"  GANS improvement              : {gans_summary['improvement']:.2f} h")
+    print(f"  GANS NS activations           : {gans_summary['n_ns_activations']}")
+    print(f"{'─' * 60}")
+    print(f"  GANS best list (first 10)     : {gans.get_best_activity_list(gans_best)[:10]}")
+    print()
+
+    return {
+        'case': case_name,
+        'n_activities': n_activities,
+        'cpm_duration': cpm_duration,
+        'best_serial_seed': best_serial,
+        'best_parallel_seed': best_parallel,
+        'best_gans': best_gans,
+        'best_known': best_known,
+        'gans_vs_best_known': gans_vs_best_known,
+        'improvement': best_rule_overall - best_gans,
+        'gans_n_ns': gans_summary['n_ns_activations'],
+    }
+
+
+def main() -> None:
+    """Run GANS on all hard j120 benchmark cases and print a summary table."""
+    best_results = load_best_known_results()
+    results = []
+
+    for case_name, json_file in CASES:
+        best_known = get_best_known_result(best_results, json_file)
+        result = run_gans_case(
+            case_name=case_name,
+            json_file=json_file,
+            best_known=best_known,
+            pop_size=60,
+            lambda_max=5000,
+            ga_stall_limit=50,
+            ns_steps=200,
+            block_size=6,
+            resource_threshold=0.75,
+            seed=42,
+            verbose=True,
+        )
+        results.append(result)
+
+    print("\n" + "=" * 90)
+    print("SUMMARY — GANS HARD CASES (PSPLIB j120, best-known comparison)")
+    print("=" * 90)
+    print(
+        f"  {'Case':<12} {'N':>6} {'CPM (h)':>10} {'Best Serial':>13} "
+        f"{'Best Parallel':>14} {'Best GANS':>12} {'Best Known':>12} "
+        f"{'GANS-BK':>9} {'Δ (h)':>8} {'NS#':>5}"
+    )
+    print("  " + "-" * 116)
+    for r in results:
+        best_known_str = f"{r['best_known']:.2f}" if r['best_known'] is not None else "n/a"
+        gans_gap_str = (
+            f"{r['gans_vs_best_known']:.2f}"
+            if r['best_known'] is not None
+            else "n/a"
+        )
+        print(
+            f"  {r['case']:<12} {r['n_activities']:>6} {r['cpm_duration']:>10.2f} "
+            f"{r['best_serial_seed']:>13.2f} {r['best_parallel_seed']:>14.2f} "
+            f"{r['best_gans']:>12.2f} {best_known_str:>12} {gans_gap_str:>9} "
+            f"{r['improvement']:>8.2f} {r['gans_n_ns']:>5}"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/CPM/gga.py
+++ b/src/CPM/gga.py
@@ -1,0 +1,915 @@
+# Copyright 2020, Battelle Energy Alliance, LLC
+# ALL RIGHTS RESERVED
+"""
+gga.py — Graph Genetic Algorithm (GGA) for Resource-Constrained Project Scheduling
+
+Implements Liu et al. (2025) "A graph-based GA for RCPSP" using an Activity-on-Node
+(AON) lag-based chromosome and a micro-GA with frozen subgraph blocks.
+
+References
+----------
+Liu, Y., Liu, X., & Huang, L. (2025). A graph-based GA for Resource-Constrained
+Project Scheduling Problems. Preprint, SSRN 5851447.
+
+Chromosome representation
+-------------------------
+A flat ``List[float]`` of non-negative lag values, one per directed arc in the
+project network (enumerated once from ``pert.forwardDict`` at construction time).
+
+For arc (i → j):  λ(i, j) = S(j) − S(i) − d(i)  (hours, ≥ 0)
+
+where S(·) are activity start times in hours from project start and d(·) is
+activity duration in hours.
+
+Conversion pipeline
+-------------------
+lags → start_times → activity_order → serial_SGS → fitness + actual_starts → corrected_lags
+
+Every genetic operator produces a fully evaluated ``Individual`` by calling
+``_improve`` (or ``_evaluate_activity_order``) internally.  The main loop therefore
+contains no separate evaluation step.
+
+Micro-GA structure (Algorithm 1)
+---------------------------------
+Small elite pool (ne, default 5).  Each generation six offspring are created—one
+per operator—merged with the elite, and the best ne survive.  A stall counter
+triggers a full population restart when no improvement occurs for
+``restart_threshold`` consecutive generations.  The all-time best individual
+(winner) is re-injected into the restarted pool so it is never lost.
+
+Individual
+----------
+Plain Python dict ``{'lags': List[float], 'fitness': float}``.  No DEAP dependency.
+
+Requirements
+------------
+    numpy, networkx  (already dependencies of pert.py)
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import random
+from collections import deque
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
+
+import networkx as nx
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Priority rules for initial-population seeding (mirrors ga.py)
+# ---------------------------------------------------------------------------
+PRIORITY_RULES: List[str] = [
+    'es', 'ef', 'ls', 'lf', 'duration', 'random',
+    'mts', 'mtp', 'grpw', 'grd', 'rr', 'avgrr',
+    'maxrr', 'minrr', 'irsm', 'wcs', 'acs',
+    'mehh_8000_b', 'mehh_3375_b', 'mehh_1000_b', 'mehh_125_b', 'gphh_b',
+]
+
+# Type alias for readability
+Individual = Dict[str, Any]   # keys: 'lags': List[float], 'fitness': float
+
+
+class RCPSPGraphGeneticAlgorithm:
+    """
+    Graph Genetic Algorithm for RCPSP using the AON lag-based chromosome.
+
+    Parameters
+    ----------
+    pert : Pert
+        Fully initialised ``Pert`` object.  ``generateInfo()`` must have been
+        called so that ``infoDict`` entries (es, ef, …) are populated.
+    ne : int
+        Elite pool size.  Forced to ≥ 2 (``random.sample`` requirement).
+        Paper default: 5.
+    n_gen : int
+        Number of GA generations.
+    restart_threshold : int
+        Consecutive generations without improvement before restarting the
+        population.  Paper: 600 for J30, 1200 for J60/J120.
+    rho : float
+        Fraction of frozen-block nodes to exclude via the strategic exclusion
+        heuristic (Algorithm 2).  Default 0.2 (paper: 20 %).
+    seed : int
+        RNG seed for reproducibility.
+    verbose : bool
+        Print per-generation statistics to stdout.
+    """
+
+    def __init__(
+        self,
+        pert,
+        ne: int = 5,
+        n_gen: int = 500,
+        restart_threshold: int = 50,
+        rho: float = 0.2,
+        seed: int = 42,
+        verbose: bool = True,
+    ) -> None:
+        self.pert = pert
+        self.ne = max(2, ne)
+        self.n_gen = n_gen
+        self.restart_threshold = restart_threshold
+        self.rho = rho
+        self.verbose = verbose
+
+        random.seed(seed)
+        np.random.seed(seed)
+
+        # Fixed activity list — order matches forwardDict insertion order
+        self._activities: List[Any] = list(pert.forwardDict.keys())
+        self._n: int = len(self._activities)
+        self._act_to_idx: Dict[Any, int] = {a: i for i, a in enumerate(self._activities)}
+
+        self._build_arc_index()
+        self._build_topo_order()
+
+        # Duration cache (float hours) to avoid repeated method calls
+        self._durations: Dict[Any, float] = {
+            a: a.returnDuration() for a in self._activities
+        }
+
+        # Dummy START / END activities — excluded from mutation target selection
+        _start = getattr(pert, 'startActivity', None)
+        _end   = getattr(pert, 'endActivity',   None)
+        self._dummy_acts: FrozenSet[Any] = frozenset(
+            a for a in [_start, _end] if a is not None
+        )
+
+        # CPM duration upper-bound (used to scale random lags)
+        self._cpm_duration: float = (
+            max(pert.infoDict[a]['ef'] for a in pert.infoDict)
+            if pert.infoDict else 1.0
+        )
+
+    # ---------------------------------------------------------------------- #
+    # Construction helpers                                                     #
+    # ---------------------------------------------------------------------- #
+
+    def _build_arc_index(self) -> None:
+        """Enumerate all arcs from forwardDict; build arc list and reverse lookup."""
+        arcs: List[Tuple[int, int]] = []
+        arc_to_idx: Dict[Tuple[int, int], int] = {}
+        for u, succs in self.pert.forwardDict.items():
+            if u not in self._act_to_idx:
+                continue
+            u_idx = self._act_to_idx[u]
+            for v in succs:
+                if v not in self._act_to_idx:
+                    continue
+                v_idx = self._act_to_idx[v]
+                key = (u_idx, v_idx)
+                if key not in arc_to_idx:
+                    arc_to_idx[key] = len(arcs)
+                    arcs.append(key)
+        self._arcs: List[Tuple[int, int]] = arcs
+        self._arc_to_idx: Dict[Tuple[int, int], int] = arc_to_idx
+
+    def _build_topo_order(self) -> None:
+        """Compute a topological ordering of all activities."""
+        g = getattr(self.pert, 'nxgraph', None)
+        if g is not None:
+            self._topo: List[Any] = [
+                a for a in nx.topological_sort(g) if a in self._act_to_idx
+            ]
+        else:
+            # Kahn's BFS fallback
+            in_deg: Dict[Any, int] = {a: 0 for a in self._activities}
+            for u, succs in self.pert.forwardDict.items():
+                for v in succs:
+                    if v in in_deg:
+                        in_deg[v] += 1
+            queue: deque = deque(a for a in self._activities if in_deg[a] == 0)
+            topo: List[Any] = []
+            while queue:
+                u = queue.popleft()
+                topo.append(u)
+                for v in self.pert.forwardDict.get(u, []):
+                    if v in in_deg:
+                        in_deg[v] -= 1
+                        if in_deg[v] == 0:
+                            queue.append(v)
+            self._topo = topo
+
+        # Position lookup for tie-breaking in _start_times_to_activity_order
+        self._topo_idx: Dict[Any, int] = {a: i for i, a in enumerate(self._topo)}
+
+    # ---------------------------------------------------------------------- #
+    # Conversion pipeline                                                      #
+    # ---------------------------------------------------------------------- #
+
+    def _lags_to_start_times(self, lags: List[float]) -> Dict[Any, float]:
+        """
+        Forward scheduling pass: compute start times (hours) from a lag vector.
+
+        S(j) = max over predecessors i of  S(i) + d(i) + λ(i, j)
+
+        Source activities (no predecessors) start at 0.
+        """
+        start: Dict[Any, float] = {a: 0.0 for a in self._activities}
+        for act in self._topo:
+            a_idx = self._act_to_idx[act]
+            for pred in self.pert.backwardDict.get(act, []):
+                if pred not in self._act_to_idx:
+                    continue
+                p_idx = self._act_to_idx[pred]
+                key = (p_idx, a_idx)
+                if key in self._arc_to_idx:
+                    lag = lags[self._arc_to_idx[key]]
+                    candidate = start[pred] + self._durations[pred] + lag
+                    if candidate > start[act]:
+                        start[act] = candidate
+        return start
+
+    def _start_times_to_activity_order(
+        self, start_times: Dict[Any, float]
+    ) -> List[Any]:
+        """
+        Sort activities by start time (ascending).
+
+        Topological index is used as a tie-breaker to guarantee a
+        precedence-feasible ordering when two activities share the same
+        computed start time.
+        """
+        return sorted(
+            self._activities,
+            key=lambda a: (start_times.get(a, 0.0), self._topo_idx.get(a, 0)),
+        )
+
+    def _correct_aon_lag(self, actual_starts: Dict[Any, float]) -> List[float]:
+        """
+        Recompute lag vector from (resource-feasible) start times.
+
+        λ(i, j) = max(0, S(j) − S(i) − d(i))
+        """
+        lags = [0.0] * len(self._arcs)
+        for k, (i_idx, j_idx) in enumerate(self._arcs):
+            ai = self._activities[i_idx]
+            aj = self._activities[j_idx]
+            lag = (
+                actual_starts.get(aj, 0.0)
+                - actual_starts.get(ai, 0.0)
+                - self._durations[ai]
+            )
+            lags[k] = max(0.0, lag)
+        return lags
+
+    def _improve(self, lags: List[float]) -> Tuple[float, List[float]]:
+        """
+        Decode a lag chromosome, run serial SGS, and correct lags from the
+        resource-feasible schedule (IMPROVE / FBI step in the paper).
+
+        Returns
+        -------
+        (makespan, corrected_lags)
+        """
+        order = self._start_times_to_activity_order(self._lags_to_start_times(lags))
+        out = self.pert.calculateSerialScheduleWithResources(_ordered=order)
+        makespan = out['scheduled_duration'] - 2
+
+        project_start = self.pert.startTime
+        actual_starts: Dict[Any, float] = {}
+        for a in self._activities:
+            if a.startTime is not None and project_start is not None:
+                actual_starts[a] = (
+                    (a.startTime - project_start).total_seconds() / 3600.0
+                )
+            else:
+                actual_starts[a] = 0.0
+
+        corrected = self._correct_aon_lag(actual_starts)
+        return makespan, corrected
+
+    def _evaluate_activity_order(self, order: List[Any]) -> Individual:
+        """
+        Run serial SGS from a given activity ordering, compute lags from the
+        resulting resource-feasible schedule, and return an evaluated Individual.
+        """
+        out = self.pert.calculateSerialScheduleWithResources(_ordered=order)
+        makespan = out['scheduled_duration'] - 2
+
+        project_start = self.pert.startTime
+        actual_starts: Dict[Any, float] = {}
+        for a in self._activities:
+            if a.startTime is not None and project_start is not None:
+                actual_starts[a] = (
+                    (a.startTime - project_start).total_seconds() / 3600.0
+                )
+            else:
+                actual_starts[a] = 0.0
+
+        corrected = self._correct_aon_lag(actual_starts)
+        return self._make_individual(corrected, makespan)
+
+    # ---------------------------------------------------------------------- #
+    # Individual factory                                                       #
+    # ---------------------------------------------------------------------- #
+
+    def _make_individual(
+        self, lags: List[float], fitness: float = math.inf
+    ) -> Individual:
+        return {'lags': list(lags), 'fitness': fitness}
+
+    def _evaluate(self, ind: Individual) -> Individual:
+        """Call _improve; update individual's fitness and lags in place."""
+        try:
+            fitness, corrected = self._improve(ind['lags'])
+            ind['fitness'] = fitness
+            ind['lags'] = corrected
+        except Exception as exc:
+            logger.warning("Evaluation failed: %s", exc)
+            ind['fitness'] = math.inf
+        return ind
+
+    # ---------------------------------------------------------------------- #
+    # Initial population                                                       #
+    # ---------------------------------------------------------------------- #
+
+    def _build_initial_population(self) -> List[Individual]:
+        """
+        Build an elite pool of ``ne`` fully-evaluated individuals.
+
+        Seeding order:
+        1. Each priority rule in ``PRIORITY_RULES`` (up to ``ne`` slots):
+           derive an activity ordering → CPM early-start lags → ``_improve``.
+        2. Zero-lag individual (all lags = 0, i.e. CPM-earliest ordering).
+        3. Random lag vectors until the pool reaches ``ne``.
+        """
+        pool: List[Individual] = []
+        seed_info: Dict[str, float] = {}
+
+        all_acts = list(self.pert.forwardDict.keys())
+        for rule in PRIORITY_RULES:
+            if len(pool) >= self.ne:
+                break
+            try:
+                self.pert.priorities = None
+                raw = self.pert.priority_calculation(all_acts, priority_rule=rule)
+                if raw and isinstance(raw[0], tuple):
+                    ordered_acts: List[Any] = [a for (a, _, _) in raw]
+                else:
+                    ordered_acts = list(raw)
+
+                # Use CPM early-start times to initialise lags for this ordering
+                cpm_starts = {
+                    a: self.pert.infoDict[a]['es'] for a in self._activities
+                }
+                init_lags = self._correct_aon_lag(cpm_starts)
+
+                ind = self._evaluate(self._make_individual(init_lags))
+                pool.append(ind)
+                seed_info[rule] = ind['fitness']
+            except Exception as exc:
+                logger.warning(
+                    "Skipping rule '%s' during GGA seeding: %s", rule, exc
+                )
+
+        # Zero-lag seed (pure CPM earliest-start ordering)
+        if len(pool) < self.ne:
+            ind = self._evaluate(self._make_individual([0.0] * len(self._arcs)))
+            pool.append(ind)
+
+        # Random fill
+        while len(pool) < self.ne:
+            lags = [
+                random.uniform(0.0, self._cpm_duration) for _ in self._arcs
+            ]
+            ind = self._evaluate(self._make_individual(lags))
+            pool.append(ind)
+
+        if self.verbose:
+            if seed_info:
+                best_s = min(seed_info.values())
+                n_rand = len(pool) - len(seed_info)
+                print(
+                    f"\nGGA initial elite: {len(seed_info)} rule-seeded + "
+                    f"{n_rand} fill  |  best seeded = {best_s:.2f} h\n"
+                )
+                print(f"  {'Rule':<22} {'Fitness (h)':>12}")
+                print("  " + "-" * 36)
+                for r, f in seed_info.items():
+                    print(f"  {r:<22} {f:>12.2f}")
+                print()
+
+        return pool
+
+    # ---------------------------------------------------------------------- #
+    # Frozen block selection — Algorithm 2                                     #
+    # ---------------------------------------------------------------------- #
+
+    def _select_frozen_block(
+        self,
+        winner: Individual,
+        block_type: Optional[str] = None,
+    ) -> FrozenSet[Any]:
+        """
+        Algorithm 2: select a frozen subgraph with strategic exclusion.
+
+        The frozen set is a collection of Activity objects whose incoming lags
+        are protected during lag-based crossover (Algorithm 3).
+
+        Parameters
+        ----------
+        winner : Individual
+            Current best individual (used only for context; frozen selection is
+            graph-structural and does not depend on lag values).
+        block_type : str or None
+            ``'forward'`` — predecessor subgraph (front block in the paper).
+            ``'backward'`` — successor subgraph (backward block).
+            ``None`` — chosen randomly each call.
+
+        Returns
+        -------
+        frozenset of Activity objects
+        """
+        non_dummy = [a for a in self._activities if a not in self._dummy_acts]
+        if len(non_dummy) < 4:
+            return frozenset()
+
+        k = random.randint(1, 3)
+        seeds = random.sample(non_dummy, min(k, len(non_dummy)))
+        btype = block_type or random.choice(['forward', 'backward'])
+
+        # BFS to collect subgraph nodes
+        collected: Set[Any] = set()
+        for seed in seeds:
+            visited_bfs: Set[Any] = set()
+            queue: deque = deque([seed])
+            while queue:
+                node = queue.popleft()
+                if node in visited_bfs:
+                    continue
+                visited_bfs.add(node)
+                collected.add(node)
+                if btype == 'forward':
+                    # Predecessor subgraph (front block: fixed incoming lags)
+                    for pred in self.pert.backwardDict.get(node, []):
+                        if pred not in self._dummy_acts and pred not in visited_bfs:
+                            queue.append(pred)
+                else:
+                    # Successor subgraph (backward block)
+                    for succ in self.pert.forwardDict.get(node, []):
+                        if succ not in self._dummy_acts and succ not in visited_bfs:
+                            queue.append(succ)
+
+        if not collected:
+            return frozenset()
+
+        # Strategic exclusion (Algorithm 2, probability 0.9)
+        if random.random() < 0.9 and len(collected) > 1:
+            q = max(1, int(self.rho * len(collected)))
+            to_remove: Set[Any] = set()
+
+            # 1. Highly-connected nodes (by nxgraph degree)
+            g = getattr(self.pert, 'nxgraph', None)
+            if g is not None:
+                by_degree = sorted(
+                    collected,
+                    key=lambda a: g.degree(a) if a in g else 0,
+                    reverse=True,
+                )
+                budget = max(1, q // 3)
+                to_remove.update(by_degree[:budget])
+
+            # 2. Long-duration nodes
+            if len(to_remove) < q:
+                remaining = collected - to_remove
+                by_dur = sorted(
+                    remaining, key=lambda a: self._durations[a], reverse=True
+                )
+                budget = max(1, (q - len(to_remove)) // 2)
+                to_remove.update(by_dur[:budget])
+
+            # 3. Random fill to reach exclusion quota
+            if len(to_remove) < q:
+                remaining = list(collected - to_remove)
+                random.shuffle(remaining)
+                to_remove.update(remaining[: q - len(to_remove)])
+
+            collected -= to_remove
+
+        return frozenset(collected)
+
+    # ---------------------------------------------------------------------- #
+    # Genetic operators                                                        #
+    # ---------------------------------------------------------------------- #
+
+    def _lag_crossover(
+        self,
+        p1: Individual,
+        p2: Individual,
+        frozen: FrozenSet[Any],
+    ) -> Individual:
+        """
+        Algorithm 3: Lag-uniform crossover with frozen block.
+
+        For each arc (u → v):
+        - If v is in the frozen set → inherit lag from p1 (protection).
+        - Otherwise → inherit from p1 or p2 with equal probability.
+
+        Two children would be symmetric; here we produce one child (the main
+        loop calls this operator multiple times with different parent pairs).
+        """
+        lags1 = p1['lags']
+        lags2 = p2['lags']
+        child_lags = list(lags1)
+
+        for k, (i_idx, j_idx) in enumerate(self._arcs):
+            act_j = self._activities[j_idx]
+            if act_j not in frozen and random.random() < 0.5:
+                child_lags[k] = lags2[k]
+
+        return self._evaluate(self._make_individual(child_lags))
+
+    def _lag_mutation(
+        self,
+        ind: Individual,
+        frozen: FrozenSet[Any],
+    ) -> Individual:
+        """
+        Algorithm 4: Node-centric lag mutation.
+
+        Select a non-frozen, non-dummy activity and shift *all* its incoming
+        lags by the same scalar δ (clamped to ≥ 0).  This moves the selected
+        activity and its whole successor subgraph forward or backward in time
+        while preserving the internal structure of the subgraph.
+
+        δ < 0 (compress, 80 % of calls): shift toward CPM earliest start.
+        δ > 0 (expand, 20 % of calls): inject additional slack.
+        """
+        candidates = [
+            a for a in self._activities
+            if a not in frozen and a not in self._dummy_acts
+        ]
+        if not candidates:
+            return self._make_individual(list(ind['lags']), ind['fitness'])
+
+        # Retry up to 10 times to find a node with incoming arcs
+        for _ in range(10):
+            node = random.choice(candidates)
+            node_idx = self._act_to_idx[node]
+            incoming = [k for k, (_, j) in enumerate(self._arcs) if j == node_idx]
+            if incoming:
+                break
+        else:
+            return self._make_individual(list(ind['lags']), ind['fitness'])
+
+        lags = list(ind['lags'])
+        min_lag = min(lags[k] for k in incoming)
+
+        if random.random() < 0.8:
+            delta = -random.uniform(0.0, min_lag)
+        else:
+            delta = random.uniform(0.0, max(0.5, self._cpm_duration / 4.0))
+
+        for k in incoming:
+            lags[k] = max(0.0, lags[k] + delta)
+
+        return self._evaluate(self._make_individual(lags))
+
+    def _day_form_crossover(
+        self,
+        winner: Individual,
+        challenger: Individual,
+        frozen: FrozenSet[Any],
+    ) -> Individual:
+        """
+        Algorithm 5: Day-form two-point crossover with frozen activity protection.
+
+        1. Convert both parents to start-time vectors aligned with _topo.
+        2. Randomly swap the segment [q1, q2) from the challenger into the
+           winner's vector.
+        3. Restore frozen activities' start times to the winner's values.
+        4. Re-derive activity ordering and run _improve (SGS + correct lags).
+        """
+        st_w = self._lags_to_start_times(winner['lags'])
+        st_c = self._lags_to_start_times(challenger['lags'])
+
+        n = len(self._topo)
+        if n < 3:
+            return self._make_individual(list(winner['lags']), winner['fitness'])
+
+        q1, q2 = sorted(random.sample(range(1, n), 2))
+
+        child_st: Dict[Any, float] = {}
+        for i, act in enumerate(self._topo):
+            if act in frozen:
+                child_st[act] = st_w.get(act, 0.0)
+            elif q1 <= i < q2:
+                child_st[act] = st_c.get(act, st_w.get(act, 0.0))
+            else:
+                child_st[act] = st_w.get(act, 0.0)
+
+        child_lags = self._correct_aon_lag(child_st)
+        return self._evaluate(self._make_individual(child_lags))
+
+    def _day_form_mutation(self, ind: Individual) -> Individual:
+        """
+        Algorithm 6: Day-form mutation — shift one activity's start time earlier.
+
+        Picks a random non-dummy activity, reduces its start time by a random
+        fraction, then rebuilds the activity ordering and runs _improve.
+        """
+        candidates = [a for a in self._activities if a not in self._dummy_acts]
+        if not candidates:
+            return self._make_individual(list(ind['lags']), ind['fitness'])
+
+        act = random.choice(candidates)
+        st = self._lags_to_start_times(ind['lags'])
+        s_act = st.get(act, 0.0)
+
+        if s_act > 0.0:
+            delta = random.uniform(0.0, s_act)
+            st[act] = s_act - delta
+
+        child_lags = self._correct_aon_lag(st)
+        return self._evaluate(self._make_individual(child_lags))
+
+    def _activity_list_crossover(
+        self,
+        winner: Individual,
+        challenger: Individual,
+        frozen: FrozenSet[Any],  # noqa: ARG002  (unused; kept for uniform API)
+    ) -> Individual:
+        """
+        Algorithm 7: One-point activity-list crossover (CORRECTOMIT + FEASIBLESEQUENCE).
+
+        1. Derive activity orderings from both parents' start times.
+        2. Choose a segment-boundary cut point (n_segments ∈ {2..6}).
+        3. Prefix from winner; remainder filled by scanning challenger and
+           appending activities not yet in the child (Hartmann 1998 style).
+        4. Repair precedence via ``pert.reorder_by_dependencies``.
+        5. Evaluate via SGS.
+        """
+        order_w = self._start_times_to_activity_order(
+            self._lags_to_start_times(winner['lags'])
+        )
+        order_c = self._start_times_to_activity_order(
+            self._lags_to_start_times(challenger['lags'])
+        )
+
+        n = len(order_w)
+        if n < 2:
+            return self._make_individual(list(winner['lags']), winner['fitness'])
+
+        # Segment-based cut point (Algorithm 7 step 1–2)
+        n_segs = random.randint(2, min(6, n))
+        seg_size = max(1, n // n_segs)
+        boundaries = list(range(seg_size, n, seg_size))
+        q = random.choice(boundaries) if boundaries else n // 2
+
+        # CORRECTOMIT: one-point order crossover (Hartmann 1998)
+        prefix = order_w[:q]
+        taken = {self._act_to_idx[a] for a in prefix}
+        suffix = [a for a in order_c if self._act_to_idx[a] not in taken]
+
+        # Ensure every activity is present exactly once
+        child_order = list(prefix) + list(suffix)
+        present = {self._act_to_idx[a] for a in child_order}
+        child_order += [a for a in self._activities if self._act_to_idx[a] not in present]
+
+        # FEASIBLESEQUENCE: topological repair
+        ranked = [(a, i) for i, a in enumerate(child_order)]
+        try:
+            repaired = self.pert.reorder_by_dependencies(ranked, self.pert.forwardDict)
+            child_order = [a for a, _ in repaired]
+        except Exception:
+            pass
+
+        return self._evaluate_activity_order(child_order)
+
+    def _activity_list_mutation(
+        self,
+        ind: Individual,
+        frozen: FrozenSet[Any],
+    ) -> Individual:
+        """
+        Algorithm 8: Frozen-aware insertion mutation on activity ordering.
+
+        1. Derive activity order from ind's start times.
+        2. With probability 0.8 pick from non-frozen non-dummy activities;
+           otherwise pick any non-dummy (small exploratory probability).
+        3. Compute feasible insertion window [lo, hi] from predecessor/
+           successor positions in the current ordering.
+        4. Relocate the chosen activity to a random position in [lo, hi].
+        5. Evaluate via SGS.
+        """
+        order = self._start_times_to_activity_order(
+            self._lags_to_start_times(ind['lags'])
+        )
+        n = len(order)
+        if n < 4:
+            return self._make_individual(list(ind['lags']), ind['fitness'])
+
+        # Position lookup (by object identity index)
+        pos_of: Dict[int, int] = {self._act_to_idx[a]: i for i, a in enumerate(order)}
+
+        non_dummy = [a for a in order if a not in self._dummy_acts]
+        non_frozen_non_dummy = [a for a in non_dummy if a not in frozen]
+
+        if not non_dummy:
+            return self._make_individual(list(ind['lags']), ind['fitness'])
+
+        if random.random() < 0.8 and non_frozen_non_dummy:
+            act = random.choice(non_frozen_non_dummy)
+        else:
+            act = random.choice(non_dummy)
+
+        act_idx = self._act_to_idx[act]
+        cur_pos = pos_of[act_idx]
+
+        # Compute feasible insertion window
+        preds = self.pert.backwardDict.get(act, [])
+        succs = self.pert.forwardDict.get(act, [])
+
+        lo = (
+            max(
+                pos_of[self._act_to_idx[p]]
+                for p in preds
+                if p in self._act_to_idx and self._act_to_idx[p] in pos_of
+            ) + 1
+            if preds else 0
+        )
+        hi = (
+            min(
+                pos_of[self._act_to_idx[s]]
+                for s in succs
+                if s in self._act_to_idx and self._act_to_idx[s] in pos_of
+            ) - 1
+            if succs else n - 1
+        )
+
+        if lo > hi:
+            return self._make_individual(list(ind['lags']), ind['fitness'])
+
+        new_pos = random.randint(lo, hi)
+        if new_pos == cur_pos:
+            return self._make_individual(list(ind['lags']), ind['fitness'])
+
+        new_order = list(order)
+        new_order.pop(cur_pos)
+        insert_at = new_pos if new_pos < cur_pos else new_pos - 1
+        new_order.insert(insert_at, act)
+
+        return self._evaluate_activity_order(new_order)
+
+    # ---------------------------------------------------------------------- #
+    # Main optimisation loop — Algorithm 1                                     #
+    # ---------------------------------------------------------------------- #
+
+    def run(self) -> Tuple[Individual, List[Dict]]:
+        """
+        Execute the micro-GA.
+
+        Workflow
+        --------
+        1. Build initial elite pool (priority-rule seeds + random fill).
+        2. For each generation:
+           a. Select frozen block from winner.
+           b. Produce six offspring (one per operator).
+           c. Merge elite + offspring; keep best ``ne``.
+           d. Update winner and stall counter.
+           e. Restart if stall ≥ restart_threshold (re-inject winner).
+
+        Returns
+        -------
+        winner : Individual
+            Best individual found across all generations and restarts.
+        log : list of dict
+            Per-generation records:
+            ``gen``, ``best``, ``pool_best``, ``stall``, ``restart``.
+        """
+        # ── Generation 0 ─────────────────────────────────────────────────────
+        elite = self._build_initial_population()
+        elite.sort(key=lambda x: x['fitness'])
+
+        winner = self._make_individual(elite[0]['lags'], elite[0]['fitness'])
+        best_ever = winner['fitness']
+        stall = 0
+        log: List[Dict] = [
+            {
+                'gen': 0,
+                'best': best_ever,
+                'pool_best': elite[0]['fitness'],
+                'stall': stall,
+                'restart': False,
+            }
+        ]
+        if self.verbose:
+            print(
+                f"gen {'0':>5} | best={best_ever:.2f} h | "
+                f"pool_best={elite[0]['fitness']:.2f} h | stall={stall}"
+            )
+
+        # ── Generational loop ─────────────────────────────────────────────────
+        for gen in range(1, self.n_gen + 1):
+            frozen = self._select_frozen_block(winner)
+
+            # Two distinct parents for lag crossover
+            p1, p2 = random.sample(elite, 2)
+            # Random elite individual for mutation operators
+            p_rand = random.choice(elite)
+
+            offspring: List[Individual] = [
+                self._day_form_crossover(winner, p_rand, frozen),      # Alg 5
+                self._lag_crossover(p1, p2, frozen),                   # Alg 3
+                self._activity_list_crossover(winner, p_rand, frozen), # Alg 7
+                self._lag_mutation(p_rand, frozen),                    # Alg 4
+                self._day_form_mutation(p_rand),                       # Alg 6
+                self._activity_list_mutation(p_rand, frozen),          # Alg 8
+            ]
+
+            # Merge and select elites
+            pool = elite + offspring
+            pool.sort(key=lambda x: x['fitness'])
+            elite = pool[: self.ne]
+
+            gen_best_fitness = elite[0]['fitness']
+            restarted = False
+
+            if gen_best_fitness < best_ever:
+                best_ever = gen_best_fitness
+                winner = self._make_individual(elite[0]['lags'], elite[0]['fitness'])
+                stall = 0
+            else:
+                stall += 1
+
+            # Stall-triggered restart
+            if stall >= self.restart_threshold:
+                elite = self._build_initial_population()
+                elite.sort(key=lambda x: x['fitness'])
+                elite[0] = self._make_individual(winner['lags'], winner['fitness'])
+                stall = 0
+                restarted = True
+
+            log.append(
+                {
+                    'gen': gen,
+                    'best': best_ever,
+                    'pool_best': gen_best_fitness,
+                    'stall': stall,
+                    'restart': restarted,
+                }
+            )
+            if self.verbose:
+                tag = " [RESTART]" if restarted else ""
+                print(
+                    f"gen {gen:>5} | best={best_ever:.2f} h | "
+                    f"pool_best={gen_best_fitness:.2f} h | stall={stall}{tag}"
+                )
+
+        logger.info(
+            "GGA finished | best = %.2f h | generations = %d | ne = %d",
+            best_ever,
+            self.n_gen,
+            self.ne,
+        )
+        return winner, log
+
+    # ---------------------------------------------------------------------- #
+    # Result helpers                                                           #
+    # ---------------------------------------------------------------------- #
+
+    def get_best_schedule(self, winner: Individual) -> Dict:
+        """
+        Decode the winner and return the full schedule result dict.
+
+        Re-runs ``calculateSerialScheduleWithResources`` with the winner's
+        implied activity ordering so that the ``Pert`` object is left in the
+        state of the best schedule.
+        """
+        order = self._start_times_to_activity_order(
+            self._lags_to_start_times(winner['lags'])
+        )
+        return self.pert.calculateSerialScheduleWithResources(_ordered=order)
+
+    def get_best_activity_list(self, winner: Individual) -> List[str]:
+        """
+        Return the winner's implied scheduling order as a list of task names.
+        """
+        order = self._start_times_to_activity_order(
+            self._lags_to_start_times(winner['lags'])
+        )
+        return [a.returnName() for a in order]
+
+    def get_convergence_summary(self, log: List[Dict]) -> Dict:
+        """
+        Extract a concise convergence summary from the generation log.
+
+        Returns
+        -------
+        dict with keys:
+            ``n_gen``, ``best_duration``, ``initial_best``, ``improvement``,
+            ``n_restarts``, ``final_stall``.
+        """
+        return {
+            'n_gen': len(log) - 1,
+            'best_duration': log[-1]['best'],
+            'initial_best': log[0]['best'],
+            'improvement': log[0]['best'] - log[-1]['best'],
+            'n_restarts': sum(1 for r in log if r.get('restart', False)),
+            'final_stall': log[-1]['stall'],
+        }

--- a/src/CPM/gga.py
+++ b/src/CPM/gga.py
@@ -145,6 +145,18 @@ class RCPSPGraphGeneticAlgorithm:
             if pert.infoDict else 1.0
         )
 
+        # Transitive successor cache used for precedence-safe insertion windows.
+        self._trans_successors: Dict[Any, Set[Any]] = {}
+        for act in reversed(self._topo):
+            direct = {
+                succ for succ in self.pert.forwardDict.get(act, [])
+                if succ in self._act_to_idx
+            }
+            trans: Set[Any] = set()
+            for succ in direct:
+                trans.update(self._trans_successors.get(succ, set()))
+            self._trans_successors[act] = direct | trans
+
     # ---------------------------------------------------------------------- #
     # Construction helpers                                                     #
     # ---------------------------------------------------------------------- #
@@ -268,18 +280,13 @@ class RCPSPGraphGeneticAlgorithm:
         """
         order = self._start_times_to_activity_order(self._lags_to_start_times(lags))
         out = self.pert.calculateSerialScheduleWithResources(_ordered=order)
+        if out.get('n_completed', 0) < out.get('n_activities', len(self._activities)):
+            return math.inf, list(lags)
         makespan = out['scheduled_duration'] - 2
 
-        project_start = self.pert.startTime
-        actual_starts: Dict[Any, float] = {}
-        for a in self._activities:
-            if a.startTime is not None and project_start is not None:
-                actual_starts[a] = (
-                    (a.startTime - project_start).total_seconds() / 3600.0
-                )
-            else:
-                actual_starts[a] = 0.0
-
+        actual_starts = self._get_actual_start_offsets()
+        if actual_starts is None:
+            return math.inf, list(lags)
         corrected = self._correct_aon_lag(actual_starts)
         return makespan, corrected
 
@@ -289,20 +296,36 @@ class RCPSPGraphGeneticAlgorithm:
         resulting resource-feasible schedule, and return an evaluated Individual.
         """
         out = self.pert.calculateSerialScheduleWithResources(_ordered=order)
+        if out.get('n_completed', 0) < out.get('n_activities', len(self._activities)):
+            return self._make_individual([0.0] * len(self._arcs), math.inf)
         makespan = out['scheduled_duration'] - 2
 
-        project_start = self.pert.startTime
-        actual_starts: Dict[Any, float] = {}
-        for a in self._activities:
-            if a.startTime is not None and project_start is not None:
-                actual_starts[a] = (
-                    (a.startTime - project_start).total_seconds() / 3600.0
-                )
-            else:
-                actual_starts[a] = 0.0
+        actual_starts = self._get_actual_start_offsets()
+        if actual_starts is None:
+            return self._make_individual([0.0] * len(self._arcs), math.inf)
 
         corrected = self._correct_aon_lag(actual_starts)
         return self._make_individual(corrected, makespan)
+
+    def _get_actual_start_offsets(self) -> Optional[Dict[Any, float]]:
+        """
+        Return actual start offsets in hours after a successful SGS run.
+
+        ``None`` indicates that at least one activity was not scheduled or that
+        the project start time is unavailable.
+        """
+        project_start = self.pert.startTime
+        if project_start is None:
+            return None
+
+        actual_starts: Dict[Any, float] = {}
+        for a in self._activities:
+            if a.startTime is None:
+                return None
+            actual_starts[a] = (
+                (a.startTime - project_start).total_seconds() / 3600.0
+            )
+        return actual_starts
 
     # ---------------------------------------------------------------------- #
     # Individual factory                                                       #
@@ -334,7 +357,7 @@ class RCPSPGraphGeneticAlgorithm:
 
         Seeding order:
         1. Each priority rule in ``PRIORITY_RULES`` (up to ``ne`` slots):
-           derive an activity ordering → CPM early-start lags → ``_improve``.
+           derive an activity ordering → serial SGS → corrected lag vector.
         2. Zero-lag individual (all lags = 0, i.e. CPM-earliest ordering).
         3. Random lag vectors until the pool reaches ``ne``.
         """
@@ -347,19 +370,15 @@ class RCPSPGraphGeneticAlgorithm:
                 break
             try:
                 self.pert.priorities = None
-                raw = self.pert.priority_calculation(all_acts, priority_rule=rule)
+                raw = self.pert.priority_calculation(
+                    list(all_acts), priority_rule=rule
+                )
                 if raw and isinstance(raw[0], tuple):
                     ordered_acts: List[Any] = [a for (a, _, _) in raw]
                 else:
                     ordered_acts = list(raw)
 
-                # Use CPM early-start times to initialise lags for this ordering
-                cpm_starts = {
-                    a: self.pert.infoDict[a]['es'] for a in self._activities
-                }
-                init_lags = self._correct_aon_lag(cpm_starts)
-
-                ind = self._evaluate(self._make_individual(init_lags))
+                ind = self._evaluate_activity_order(ordered_acts)
                 pool.append(ind)
                 seed_info[rule] = ind['fitness']
             except Exception as exc:
@@ -455,6 +474,14 @@ class RCPSPGraphGeneticAlgorithm:
                         if succ not in self._dummy_acts and succ not in visited_bfs:
                             queue.append(succ)
 
+        if btype == 'backward':
+            frontier: Set[Any] = set()
+            for node in list(collected):
+                for pred in self.pert.backwardDict.get(node, []):
+                    if pred not in self._dummy_acts:
+                        frontier.add(pred)
+            collected.update(frontier)
+
         if not collected:
             return frozenset()
 
@@ -506,9 +533,10 @@ class RCPSPGraphGeneticAlgorithm:
         """
         Algorithm 3: Lag-uniform crossover with frozen block.
 
-        For each arc (u → v):
-        - If v is in the frozen set → inherit lag from p1 (protection).
-        - Otherwise → inherit from p1 or p2 with equal probability.
+        For each activity v:
+        - If v is in the frozen set → inherit all incoming lags from p1.
+        - Otherwise → inherit v's incoming lag bundle from p1 or p2 with
+          equal probability.
 
         Two children would be symmetric; here we produce one child (the main
         loop calls this operator multiple times with different parent pairs).
@@ -517,9 +545,15 @@ class RCPSPGraphGeneticAlgorithm:
         lags2 = p2['lags']
         child_lags = list(lags1)
 
-        for k, (i_idx, j_idx) in enumerate(self._arcs):
+        incoming_by_target: Dict[int, List[int]] = {}
+        for k, (_, j_idx) in enumerate(self._arcs):
+            incoming_by_target.setdefault(j_idx, []).append(k)
+
+        for j_idx, arc_indices in incoming_by_target.items():
             act_j = self._activities[j_idx]
-            if act_j not in frozen and random.random() < 0.5:
+            if act_j in frozen or random.random() >= 0.5:
+                continue
+            for k in arc_indices:
                 child_lags[k] = lags2[k]
 
         return self._evaluate(self._make_individual(child_lags))
@@ -580,8 +614,7 @@ class RCPSPGraphGeneticAlgorithm:
         Algorithm 5: Day-form two-point crossover with frozen activity protection.
 
         1. Convert both parents to start-time vectors aligned with _topo.
-        2. Randomly swap the segment [q1, q2) from the challenger into the
-           winner's vector.
+        2. Build the four two-point segment-exchange variants and choose one.
         3. Restore frozen activities' start times to the winner's values.
         4. Re-derive activity ordering and run _improve (SGS + correct lags).
         """
@@ -594,14 +627,25 @@ class RCPSPGraphGeneticAlgorithm:
 
         q1, q2 = sorted(random.sample(range(1, n), 2))
 
-        child_st: Dict[Any, float] = {}
-        for i, act in enumerate(self._topo):
-            if act in frozen:
-                child_st[act] = st_w.get(act, 0.0)
-            elif q1 <= i < q2:
-                child_st[act] = st_c.get(act, st_w.get(act, 0.0))
-            else:
-                child_st[act] = st_w.get(act, 0.0)
+        candidates: List[Dict[Any, float]] = []
+        for base_st, donor_st in ((st_w, st_c), (st_c, st_w)):
+            inside: Dict[Any, float] = {}
+            outside: Dict[Any, float] = {}
+            for i, act in enumerate(self._topo):
+                in_segment = q1 <= i < q2
+                inside[act] = (
+                    donor_st.get(act, base_st.get(act, 0.0))
+                    if in_segment else base_st.get(act, 0.0)
+                )
+                outside[act] = (
+                    base_st.get(act, 0.0)
+                    if in_segment else donor_st.get(act, base_st.get(act, 0.0))
+                )
+            candidates.extend([inside, outside])
+
+        child_st = random.choice(candidates)
+        for act in frozen:
+            child_st[act] = st_w.get(act, 0.0)
 
         child_lags = self._correct_aon_lag(child_st)
         return self._evaluate(self._make_individual(child_lags))
@@ -723,7 +767,7 @@ class RCPSPGraphGeneticAlgorithm:
 
         # Compute feasible insertion window
         preds = self.pert.backwardDict.get(act, [])
-        succs = self.pert.forwardDict.get(act, [])
+        succs = self._trans_successors.get(act, set())
 
         lo = (
             max(
@@ -839,9 +883,18 @@ class RCPSPGraphGeneticAlgorithm:
 
             # Stall-triggered restart
             if stall >= self.restart_threshold:
-                elite = self._build_initial_population()
-                elite.sort(key=lambda x: x['fitness'])
-                elite[0] = self._make_individual(winner['lags'], winner['fitness'])
+                fresh_elite = self._build_initial_population()
+                fresh_elite.append(
+                    self._make_individual(winner['lags'], winner['fitness'])
+                )
+                fresh_elite.sort(key=lambda x: x['fitness'])
+                elite = fresh_elite[: self.ne]
+                if elite[0]['fitness'] < best_ever:
+                    best_ever = elite[0]['fitness']
+                    winner = self._make_individual(
+                        elite[0]['lags'], elite[0]['fitness']
+                    )
+                gen_best_fitness = elite[0]['fitness']
                 stall = 0
                 restarted = True
 

--- a/src/CPM/gga_test.py
+++ b/src/CPM/gga_test.py
@@ -1,0 +1,206 @@
+"""
+gga_test.py — Integration test for the RCPSP Graph Genetic Algorithm (gga.py)
+
+Runs the GGA on each PSPLIB benchmark JSON (j30, j60, j90, j120) and prints
+a comparison table of:
+  - Best duration from all named priority rules (serial SGS baseline)
+  - Best GGA duration (AON lag chromosome + serial SGS decoder)
+  - Improvement over the best seeded solution and over the priority-rule baseline
+
+The GGA uses an Activity-on-Node (AON) lag-based chromosome with a micro-GA
+structure and frozen subgraph blocks (Liu et al., 2025).
+
+Reference
+---------
+Liu, Y., Liu, X., and Huang, L. (2025). A graph-based genetic algorithm for
+resource-constrained project scheduling problems. SSRN 5851447.
+
+Usage (from the src/CPM directory):
+    python gga_test.py
+
+Or from the repo root:
+    python -m src.CPM.gga_test
+"""
+
+import sys
+import logging
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from src import Pert  # noqa: E402
+from src.CPM.gga import RCPSPGraphGeneticAlgorithm, PRIORITY_RULES  # noqa: E402
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+SCHEMA = Path(__file__).parent / "outage_schema.json"
+
+CASES = [
+    ("j30",  "j301_1.json"),
+    ("j60",  "j601_1.json"),
+    ("j90",  "j901_1.json"),
+    ("j120", "j1201_1.json"),
+]
+
+
+def run_gga_case(
+    case_name: str,
+    json_file: str,
+    ne: int = 50,
+    n_gen: int = 500,
+    restart_threshold: int = 50,
+    rho: float = 0.2,
+    seed: int = 42,
+    verbose: bool = True,
+) -> dict:
+    """
+    Run the GGA on a single PSPLIB benchmark case.
+
+    Steps
+    -----
+    1. Load and initialise the Pert model.
+    2. Record baseline durations for every named priority rule under serial SGS
+       (same evaluations used to seed the GGA's initial population).
+    3. Run the GGA (AON lag chromosome, micro-GA, serial SGS decoder).
+    4. Print per-case results and return a summary dict.
+
+    Parameters
+    ----------
+    case_name : str
+        Human-readable label (e.g. 'j30').
+    json_file : str
+        Path to the input JSON relative to this file's directory.
+    ne : int
+        Elite pool size (micro-GA).
+    n_gen : int
+        Number of GA generations.
+    restart_threshold : int
+        Generations without improvement before population restart.
+    rho : float
+        Exclusion fraction for frozen-block node removal (Algorithm 2).
+    seed : int
+        RNG seed.
+    verbose : bool
+        Print per-generation stats and seeding table.
+
+    Returns
+    -------
+    dict with keys:
+        case, n_activities, cpm_duration,
+        best_serial_seed, best_gga, improvement, n_restarts
+    """
+    json_path = Path(__file__).parent / json_file
+
+    print("=" * 70)
+    print(f"Case: {case_name}  ({json_file})")
+    print("=" * 70)
+
+    pert = Pert.from_json_file(str(json_path), schema_path=str(SCHEMA))
+    pert.generateInfo()
+
+    cpm_duration = pert.getProjectDuration()
+    n_activities = len(pert.infoDict)
+
+    print(f"Activities      : {n_activities}")
+    print(f"CPM duration    : {cpm_duration:.2f} h  (unconstrained)")
+    print()
+
+    # ── Baseline: best duration from all named priority rules (serial SGS) ──
+    serial_durations = {}
+    for rule in PRIORITY_RULES:
+        try:
+            pert.priorities = None
+            s_out = pert.calculateSerialScheduleWithResources(priority_rule=rule)
+            serial_durations[rule] = s_out['scheduled_duration'] - 2
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Rule '%s' skipped in baseline: %s", rule, exc)
+
+    best_serial = (
+        min(serial_durations.values()) if serial_durations else float('inf')
+    )
+
+    if verbose:
+        print("Priority rule baseline durations (serial SGS):")
+        print(f"  {'Rule':<22} {'Serial (h)':>12}")
+        print("  " + "-" * 36)
+        for rule in PRIORITY_RULES:
+            s = serial_durations.get(rule, float('nan'))
+            print(f"  {rule:<22} {s:>12.2f}")
+        print()
+
+    # ── Run GGA ─────────────────────────────────────────────────────────────
+    print(f"Running GGA (ne={ne}, n_gen={n_gen}, restart={restart_threshold}, rho={rho})...")
+    gga = RCPSPGraphGeneticAlgorithm(
+        pert,
+        ne=ne,
+        n_gen=n_gen,
+        restart_threshold=restart_threshold,
+        rho=rho,
+        seed=seed,
+        verbose=verbose,
+    )
+    winner, log = gga.run()
+
+    best_gga = winner['fitness']
+    summary = gga.get_convergence_summary(log)
+    best_activity_list = gga.get_best_activity_list(winner)
+
+    print()
+    print(f"{'─' * 60}")
+    print(f"  CPM duration (unconstrained)  : {cpm_duration:.2f} h")
+    print(f"  Best serial SGS (all rules)   : {best_serial:.2f} h")
+    print(f"  Best GGA duration             : {best_gga:.2f} h")
+    print(f"  Improvement over best seed    : {summary['initial_best'] - best_gga:.2f} h")
+    print(f"  Improvement over best rule    : {best_serial - best_gga:.2f} h")
+    print(f"  Restarts                      : {summary['n_restarts']}")
+    print(f"  Final stall count             : {summary['final_stall']}")
+    print(f"{'─' * 60}")
+    print(f"  Best activity list (first 10) : {best_activity_list[:10]}")
+    print()
+
+    return {
+        'case': case_name,
+        'n_activities': n_activities,
+        'cpm_duration': cpm_duration,
+        'best_serial_seed': best_serial,
+        'best_gga': best_gga,
+        'improvement': best_serial - best_gga,
+        'n_restarts': summary['n_restarts'],
+    }
+
+
+def main() -> None:
+    """Run the GGA on all benchmark cases and print a summary table."""
+    results = []
+    for case_name, json_file in CASES:
+        result = run_gga_case(
+            case_name=case_name,
+            json_file=json_file,
+            ne=50,
+            n_gen=1000,
+            restart_threshold=50,
+            rho=0.2,
+            seed=42,
+            verbose=True,
+        )
+        results.append(result)
+
+    print("\n" + "=" * 80)
+    print("SUMMARY — GGA (AON lag chromosome, micro-GA, serial SGS decoder)")
+    print("=" * 80)
+    print(
+        f"  {'Case':<8} {'N':>6} {'CPM (h)':>10} "
+        f"{'Best Serial':>13} {'Best GGA':>10} {'Δ (h)':>8} {'Restarts':>10}"
+    )
+    print("  " + "-" * 70)
+    for r in results:
+        print(
+            f"  {r['case']:<8} {r['n_activities']:>6} {r['cpm_duration']:>10.2f} "
+            f"{r['best_serial_seed']:>13.2f} {r['best_gga']:>10.2f} "
+            f"{r['improvement']:>8.2f} {r['n_restarts']:>10}"
+        )
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit_tests/CPM/test_ga.py
+++ b/tests/unit_tests/CPM/test_ga.py
@@ -329,6 +329,23 @@ class TestConstructor:
         )
         assert g.fb_improvement is False
 
+    def test_invalid_max_evals_raises(self, pert):
+        with pytest.raises(ValueError, match="max_evals"):
+            RCPSPGeneticAlgorithm(
+                pert,
+                pop_size=5,
+                max_evals=4,
+                verbose=False,
+            )
+
+    def test_invalid_stall_generations_raises(self, pert):
+        with pytest.raises(ValueError, match="stall_generations"):
+            RCPSPGeneticAlgorithm(
+                pert,
+                stall_generations=0,
+                verbose=False,
+            )
+
     def test_custom_fb_freq(self, pert):
         g = RCPSPGeneticAlgorithm(
             pert, pop_size=3, n_gen=1, verbose=False, fb_freq=5
@@ -771,6 +788,11 @@ class TestRun:
         g, _, log = run_results
         assert len(log) == g.n_gen + 1
 
+    def test_log_has_stopping_fields(self, run_results):
+        _, _, log = run_results
+        expected = {'evals', 'best', 'stall', 'unique_schedules', 'stop_reason'}
+        assert expected.issubset(log[-1].keys())
+
     def test_best_fitness_is_finite(self, run_results):
         _, hof, _ = run_results
         best = hof[0].fitness.values[0]
@@ -797,11 +819,28 @@ class TestRun:
         act_list = g.get_best_activity_list(hof)
         assert all(isinstance(name, str) for name in act_list)
 
+    def test_plot_convergence_returns_figure(self, run_results, tmp_path):
+        """GA convergence log should render and optionally save to disk."""
+        import matplotlib
+        matplotlib.use('Agg', force=True)
+        import matplotlib.pyplot as plt
+
+        g, _, log = run_results
+        output = tmp_path / 'ga_convergence.png'
+        fig, ax = g.plot_convergence(log, filename=str(output), show=False)
+
+        assert output.exists()
+        assert ax.get_xlabel() == 'Generation'
+        assert ax.get_ylabel() == 'Schedule duration (h)'
+        assert len(ax.lines) >= 2
+        plt.close(fig)
+
     def test_get_convergence_summary_keys(self, run_results):
         g, _, log = run_results
         summary = g.get_convergence_summary(log)
         expected = {'n_gen', 'best_duration', 'initial_best',
-                    'improvement', 'final_avg', 'final_std'}
+                    'improvement', 'final_avg', 'final_std',
+                    'n_evals', 'n_unique_schedules', 'stop_reason'}
         assert expected == set(summary.keys())
 
     def test_convergence_summary_n_gen(self, run_results):
@@ -814,6 +853,67 @@ class TestRun:
         summary = g.get_convergence_summary(log)
         assert summary['improvement'] >= -1e-9, \
             f"Unexpected regression: {summary['improvement']}"
+
+    def test_target_fitness_stops_after_initial_population(self, pert):
+        g = RCPSPGeneticAlgorithm(
+            pert,
+            pop_size=5,
+            n_gen=20,
+            target_fitness=10_000.0,
+            fb_improvement=False,
+            verbose=False,
+            seed=3,
+        )
+        _, log = g.run()
+        assert len(log) == 1
+        assert g.stop_reason == 'target_fitness'
+        assert log[-1]['stop_reason'] == 'target_fitness'
+
+    def test_max_evals_stops_before_extra_generation(self, pert):
+        g = RCPSPGeneticAlgorithm(
+            pert,
+            pop_size=5,
+            n_gen=20,
+            max_evals=5,
+            fb_improvement=False,
+            verbose=False,
+            seed=4,
+        )
+        _, log = g.run()
+        assert len(log) == 1
+        assert log[-1]['evals'] == 5
+        assert g.stop_reason == 'max_evals'
+
+    def test_stall_generations_stops_early(self, pert):
+        g = RCPSPGeneticAlgorithm(
+            pert,
+            pop_size=5,
+            n_gen=20,
+            cxpb=0.0,
+            mutpb=0.0,
+            stall_generations=1,
+            fb_improvement=False,
+            verbose=False,
+            seed=5,
+        )
+        _, log = g.run()
+        assert len(log) <= 2
+        assert g.stop_reason == 'stall_generations'
+
+    def test_unique_schedule_budget_is_tracked(self, pert):
+        g = RCPSPGeneticAlgorithm(
+            pert,
+            pop_size=5,
+            n_gen=20,
+            max_unique_schedules=1,
+            fb_improvement=False,
+            verbose=False,
+            seed=6,
+        )
+        _, log = g.run()
+        assert len(log) == 1
+        assert log[-1]['unique_schedules'] >= 1
+        assert g.stop_reason == 'max_unique_schedules'
 
     @pytest.mark.parametrize("cx,mut", [
         ('one_point',    'swap'),

--- a/tests/unit_tests/CPM/test_ga.py
+++ b/tests/unit_tests/CPM/test_ga.py
@@ -317,6 +317,24 @@ class TestConstructor:
         with pytest.raises(ValueError, match="mutation"):
             RCPSPGeneticAlgorithm(pert, crossover='one_point', mutation='bogus')
 
+    def test_default_fb_improvement(self, ga):
+        assert ga.fb_improvement is True
+
+    def test_default_fb_freq(self, ga):
+        assert ga.fb_freq == 0
+
+    def test_custom_fb_improvement_false(self, pert):
+        g = RCPSPGeneticAlgorithm(
+            pert, pop_size=3, n_gen=1, verbose=False, fb_improvement=False
+        )
+        assert g.fb_improvement is False
+
+    def test_custom_fb_freq(self, pert):
+        g = RCPSPGeneticAlgorithm(
+            pert, pop_size=3, n_gen=1, verbose=False, fb_freq=5
+        )
+        assert g.fb_freq == 5
+
     def test_toolbox_mate_registered(self, ga):
         assert hasattr(ga.toolbox, 'mate')
 
@@ -621,7 +639,105 @@ class TestMutateInsertionWindow:
 
 
 # =============================================================================
-# 11. End-to-end run
+# 11. Forward-Backward-Forward improvement
+# =============================================================================
+
+class TestFBImprovement:
+
+    def test_backward_chromosome_is_valid_permutation(self, ga):
+        """_compute_backward_chromosome must return a full permutation."""
+        chrom = ga._rule_to_chromosome('lf')
+        bwd_chrom, makespan_h = ga._compute_backward_chromosome(chrom)
+        assert sorted(bwd_chrom) == list(range(ga._n))
+        assert len(bwd_chrom) == ga._n
+
+    def test_backward_chromosome_makespan_positive(self, ga):
+        chrom = ga._rule_to_chromosome('lf')
+        _, makespan_h = ga._compute_backward_chromosome(chrom)
+        assert makespan_h > 0
+
+    def test_backward_chromosome_precedence_feasible(self, ga):
+        """The backward-ordered chromosome must respect all precedence constraints."""
+        chrom = ga._rule_to_chromosome('mts')
+        bwd_chrom, _ = ga._compute_backward_chromosome(chrom)
+        acts = ga._chromosome_to_activities(bwd_chrom)
+        pos = {a: i for i, a in enumerate(acts)}
+        for act, preds in ga.pert.backwardDict.items():
+            if act not in pos:
+                continue
+            for pred in preds:
+                if pred in pos:
+                    assert pos[pred] < pos[act], (
+                        f"Precedence violated: {pred} before {act}"
+                    )
+
+    def test_fb_improvement_returns_valid_permutation(self, ga):
+        """_fb_improvement must return a full permutation and a float fitness."""
+        chrom = ga._rule_to_chromosome('lf')
+        best_chrom, best_fit = ga._fb_improvement(chrom)
+        assert sorted(best_chrom) == list(range(ga._n))
+        assert isinstance(best_fit, (int, float))
+
+    @pytest.mark.parametrize("rule", ['es', 'lf', 'mts', 'grpw', 'random'])
+    def test_fb_improvement_never_worsens(self, ga, rule):
+        """FBF must return fitness ≤ the original forward-pass fitness."""
+        chrom = ga._rule_to_chromosome(rule)
+        (orig_fit,) = ga._evaluate(chrom)
+        _, fb_fit = ga._fb_improvement(chrom)
+        assert fb_fit <= orig_fit + 1e-9, (
+            f"FBF worsened '{rule}': {orig_fit:.2f} → {fb_fit:.2f}"
+        )
+
+    def test_fb_improvement_precedence_feasible(self, ga):
+        """The chromosome returned by _fb_improvement must be precedence-feasible."""
+        chrom = ga._rule_to_chromosome('mts')
+        best_chrom, _ = ga._fb_improvement(chrom)
+        acts = ga._chromosome_to_activities(best_chrom)
+        pos = {a: i for i, a in enumerate(acts)}
+        for act, preds in ga.pert.backwardDict.items():
+            if act not in pos:
+                continue
+            for pred in preds:
+                if pred in pos:
+                    assert pos[pred] < pos[act]
+
+    def test_apply_fb_improvement_returns_int(self, ga):
+        """apply_fb_improvement must return an int count of improved individuals."""
+        pop = ga.generate_initial_population()
+        for ind in pop:
+            ind.fitness.values = ga._evaluate(ind)
+        result = ga.apply_fb_improvement(pop)
+        assert isinstance(result, int)
+        assert 0 <= result <= len(pop)
+
+    def test_apply_fb_improvement_never_worsens(self, ga):
+        """No individual's fitness may increase after apply_fb_improvement."""
+        pop = ga.generate_initial_population()
+        for ind in pop:
+            ind.fitness.values = ga._evaluate(ind)
+        before = [ind.fitness.values[0] for ind in pop]
+        ga.apply_fb_improvement(pop)
+        for i, (ind, orig) in enumerate(zip(pop, before)):
+            assert ind.fitness.values[0] <= orig + 1e-9, (
+                f"Individual {i} worsened: {orig:.2f} → {ind.fitness.values[0]:.2f}"
+            )
+
+    def test_apply_fb_improvement_updates_fitness_when_improved(self, ga):
+        """Individuals that improve must have updated fitness values."""
+        pop = ga.generate_initial_population()
+        for ind in pop:
+            ind.fitness.values = ga._evaluate(ind)
+        before = [ind.fitness.values[0] for ind in pop]
+        n_improved = ga.apply_fb_improvement(pop)
+        actual_improved = sum(
+            1 for ind, orig in zip(pop, before)
+            if ind.fitness.values[0] < orig - 1e-9
+        )
+        assert n_improved == actual_improved
+
+
+# =============================================================================
+# 12. End-to-end run
 # =============================================================================
 
 class TestRun:
@@ -714,6 +830,46 @@ class TestRun:
         hof, log = g.run()
         assert len(hof) > 0
         assert len(log) == g.n_gen + 1
+
+    def test_run_fb_improvement_disabled(self, pert):
+        """GA must complete when FBF improvement is disabled."""
+        g = RCPSPGeneticAlgorithm(
+            pert, pop_size=5, n_gen=2, verbose=False,
+            fb_improvement=False, seed=1,
+        )
+        hof, log = g.run()
+        assert len(hof) > 0
+        assert len(log) == g.n_gen + 1
+
+    def test_run_fb_freq_periodic(self, pert):
+        """GA must complete with periodic FBF enabled and log length unchanged."""
+        g = RCPSPGeneticAlgorithm(
+            pert, pop_size=5, n_gen=4, verbose=False,
+            fb_improvement=True, fb_freq=2, seed=2,
+        )
+        hof, log = g.run()
+        assert len(hof) > 0
+        assert len(log) == g.n_gen + 1  # FBF does not add log entries
+
+    def test_run_fb_hof_fitness_not_worse_than_pre_fb(self, pert):
+        """HoF best fitness with FBF must be ≤ HoF best fitness without FBF."""
+        g_no_fb = RCPSPGeneticAlgorithm(
+            pert, pop_size=8, n_gen=5, verbose=False,
+            fb_improvement=False, seed=3,
+        )
+        hof_no_fb, _ = g_no_fb.run()
+        best_no_fb = hof_no_fb[0].fitness.values[0]
+
+        g_fb = RCPSPGeneticAlgorithm(
+            pert, pop_size=8, n_gen=5, verbose=False,
+            fb_improvement=True, seed=3,
+        )
+        hof_fb, _ = g_fb.run()
+        best_fb = hof_fb[0].fitness.values[0]
+
+        assert best_fb <= best_no_fb + 1e-9, (
+            f"FBF worsened HoF best: {best_no_fb:.2f} → {best_fb:.2f}"
+        )
 
 
 # =============================================================================

--- a/tests/unit_tests/CPM/test_ga.py
+++ b/tests/unit_tests/CPM/test_ga.py
@@ -291,6 +291,10 @@ class TestConstructor:
         """Default mutation operator must be 'adjacent_swap'."""
         assert ga.mutation == 'adjacent_swap'
 
+    def test_default_n_random(self, ga):
+        """Default consensus-library random reference count must be 8."""
+        assert ga.n_random == 8
+
     def test_crossover_method_map(self):
         """_CROSSOVER_METHODS must contain all documented choices."""
         assert set(RCPSPGeneticAlgorithm._CROSSOVER_METHODS) == {
@@ -300,7 +304,7 @@ class TestConstructor:
     def test_mutation_method_map(self):
         """_MUTATION_METHODS must contain all documented choices."""
         assert set(RCPSPGeneticAlgorithm._MUTATION_METHODS) == {
-            'swap', 'adjacent_swap', 'insertion_window'
+            'swap', 'adjacent_swap', 'insertion_window', 'consensus_reorder'
         }
 
     def test_invalid_crossover_raises(self, pert):
@@ -325,15 +329,17 @@ class TestConstructor:
         ('uniform_order', 'insertion_window'),
         ('one_point',    'insertion_window'),
         ('uniform_order', 'swap'),
+        ('two_point',    'consensus_reorder'),
     ])
     def test_operator_selection(self, pert, cx, mut):
         """All valid crossover/mutation combinations must construct without error."""
         g = RCPSPGeneticAlgorithm(
-            pert, pop_size=3, n_gen=1, verbose=False,
+            pert, pop_size=3, n_gen=1, n_random=3, verbose=False,
             crossover=cx, mutation=mut,
         )
         assert g.crossover == cx
         assert g.mutation == mut
+        assert g.n_random == 3
 
 
 # =============================================================================
@@ -697,12 +703,13 @@ class TestRun:
         ('one_point',    'swap'),
         ('two_point',    'adjacent_swap'),
         ('uniform_order', 'insertion_window'),
+        ('two_point',    'consensus_reorder'),
     ])
     def test_all_operator_combinations_complete(self, pert, cx, mut):
         """Every valid crossover/mutation pair must complete a short run."""
         g = RCPSPGeneticAlgorithm(
             pert, pop_size=5, n_gen=2, verbose=False,
-            crossover=cx, mutation=mut, seed=0,
+            crossover=cx, mutation=mut, seed=0, n_random=3,
         )
         hof, log = g.run()
         assert len(hof) > 0

--- a/tests/unit_tests/CPM/test_gans.py
+++ b/tests/unit_tests/CPM/test_gans.py
@@ -1,0 +1,735 @@
+"""
+Unit tests for gans.py — RCPSPHybridGANS
+
+Tests are organized in five tiers:
+
+  1. Constructor / structural tests (default attributes, activity-index round-trips)
+  2. Helper / pure-logic tests
+       _chromosome_to_activities, _rule_to_order, _repair,
+       _weighted_residual, _rank_resources / _randomize_weights
+  3. Schedule-decode and ordering tests
+       _decode_fitness, _get_schedule_times, _order_from_schedule, _fbi
+  4. Operator tests (require Pert)
+       _dense_activities, _crossover_A, _crossover_B, _mutate,
+       _build_initial_population, _select_parents,
+       _na_neighbor, _nb_neighbor,
+       _update_block_size, _assign_subset_params
+  5. End-to-end smoke tests
+       run, get_best_schedule, get_best_activity_list, get_convergence_summary
+
+Usage (from repo root):
+    pytest tests/unit_tests/CPM/test_gans.py -v
+"""
+
+import math
+import random
+import sys
+from pathlib import Path
+
+import pytest
+
+# ── path setup ────────────────────────────────────────────────────────────────
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.CPM.pert import Pert                              # noqa: E402
+from src.CPM.gans import RCPSPHybridGANS, PRIORITY_RULES  # noqa: E402
+
+# ── fixture paths ─────────────────────────────────────────────────────────────
+CPM_DIR   = REPO_ROOT / 'tests' / 'unit_tests' / 'CPM'
+JSON_PATH = str(CPM_DIR / 'j301_1.json')
+SCHEMA    = str(REPO_ROOT / 'src' / 'CPM' / 'outage_schema.json')
+
+
+@pytest.fixture(scope='module')
+def pert():
+    """Fully initialised Pert object for j301_1.json (PSPLIB j30 instance 1)."""
+    p = Pert.from_json_file(JSON_PATH, schema_path=SCHEMA)
+    p.generateInfo()
+    return p
+
+
+@pytest.fixture(scope='module')
+def gans(pert):
+    """GANS instance with a small budget for fast testing."""
+    return RCPSPHybridGANS(
+        pert,
+        pop_size=5,
+        lambda_max=500,
+        ga_stall_limit=10,
+        ns_steps=5,
+        block_size=3,
+        seed=0,
+        verbose=False,
+    )
+
+
+# =============================================================================
+# 1. Constructor / structural tests
+# =============================================================================
+
+class TestConstructor:
+
+    def test_activity_count(self, pert, gans):
+        assert gans._n == len(list(pert.forwardDict.keys()))
+
+    def test_act_to_idx_inverse(self, gans):
+        """_act_to_idx must be the inverse of _activities."""
+        for i, act in enumerate(gans._activities):
+            assert gans._act_to_idx[act] == i
+
+    def test_activities_match_forward_dict(self, pert, gans):
+        assert set(gans._activities) == set(pert.forwardDict.keys())
+
+    def test_pop_size_minimum(self, pert):
+        """pop_size is clamped to at least 4."""
+        g = RCPSPHybridGANS(pert, pop_size=1, lambda_max=50, verbose=False)
+        assert g.pop_size >= 4
+
+    def test_parents_size_capped(self, pert):
+        """parents_size is capped to pop_size."""
+        g = RCPSPHybridGANS(pert, pop_size=5, parents_size=100,
+                             lambda_max=50, verbose=False)
+        assert g.parents_size <= g.pop_size
+
+    def test_default_block_size_stored(self, gans):
+        assert gans.block_size == 3
+        assert gans._block_size == 3
+
+    def test_topo_idx_covers_all_activities(self, gans):
+        """Every activity in _activities must have a topological index."""
+        for a in gans._activities:
+            assert a in gans._topo_idx
+
+    def test_topo_idx_is_unique(self, gans):
+        """Topological indices must be unique."""
+        vals = list(gans._topo_idx.values())
+        assert len(vals) == len(set(vals))
+
+    def test_dummy_acts_subset_of_activities(self, gans):
+        for a in gans._dummy_acts:
+            assert a in gans._act_to_idx
+
+    def test_resource_weights_dict_exists(self, gans):
+        assert isinstance(gans._resource_weights, dict)
+
+    def test_make_individual_defaults(self, gans):
+        ind = gans._make_individual([0, 1, 2])
+        assert ind['fitness'] == math.inf
+        assert ind['order'] == [0, 1, 2]
+
+
+# =============================================================================
+# 2. Helper / pure-logic tests
+# =============================================================================
+
+class TestChromosomeHelpers:
+
+    def test_chromosome_to_activities_identity(self, gans):
+        identity = list(range(gans._n))
+        acts = gans._chromosome_to_activities(identity)
+        assert acts == gans._activities
+
+    def test_chromosome_to_activities_length(self, gans):
+        order = list(range(gans._n))
+        assert len(gans._chromosome_to_activities(order)) == gans._n
+
+    def test_rule_to_order_is_permutation(self, gans):
+        order = gans._rule_to_order('lf')
+        assert sorted(order) == list(range(gans._n))
+
+    def test_rule_to_order_random_is_permutation(self, gans):
+        order = gans._rule_to_order('random')
+        assert sorted(order) == list(range(gans._n))
+
+    @pytest.mark.parametrize("rule", ['es', 'ef', 'ls', 'lf', 'duration',
+                                       'mts', 'mtp', 'grpw'])
+    def test_named_rules_produce_permutations(self, gans, rule):
+        order = gans._rule_to_order(rule)
+        assert sorted(order) == list(range(gans._n)), \
+            f"Rule '{rule}' did not produce a permutation"
+
+    def test_repair_returns_permutation(self, gans):
+        """_repair must return a list covering all activity indices."""
+        order = list(reversed(range(gans._n)))
+        repaired = gans._repair(order)
+        assert sorted(repaired) == list(range(gans._n))
+
+    def test_repair_respects_precedence(self, gans):
+        """After repair, every predecessor must appear before its successor."""
+        order = list(reversed(range(gans._n)))
+        repaired = gans._repair(order)
+        acts = gans._chromosome_to_activities(repaired)
+        pos = {a: i for i, a in enumerate(acts)}
+        for act, preds in gans.pert.backwardDict.items():
+            if act not in pos:
+                continue
+            for pred in preds:
+                if pred in pos:
+                    assert pos[pred] < pos[act], (
+                        f"Precedence violated: {pred} (pos {pos[pred]}) "
+                        f"must precede {act} (pos {pos[act]})"
+                    )
+
+
+class TestResourceHelpers:
+
+    def test_rank_resources_returns_list(self, gans):
+        ranked = gans._rank_resources()
+        assert isinstance(ranked, list)
+
+    def test_resource_weights_after_randomize(self, gans):
+        """All skill IDs must appear in _resource_weights after randomization."""
+        gans._randomize_weights()
+        for sk in gans._skill_ids:
+            assert sk in gans._resource_weights
+
+    def test_weighted_residual_no_resources(self, gans):
+        """With no resources, fallback path returns a value in [0, 1]."""
+        original = gans._skill_ids
+        gans._skill_ids = []
+        v = gans._weighted_residual([])
+        gans._skill_ids = original
+        assert 0.0 <= v <= 1.0
+
+    def test_weighted_residual_all_idle(self, gans):
+        """When no activities are running, residual should be >= 0."""
+        v = gans._weighted_residual([])
+        assert v >= 0.0
+
+    def test_weighted_residual_range(self, gans):
+        """Residual with some active activities must be non-negative."""
+        acts = gans._activities[:3]
+        v = gans._weighted_residual(acts)
+        assert v >= 0.0
+
+
+# =============================================================================
+# 3. Schedule-decode and ordering tests
+# =============================================================================
+
+class TestDecodeAndOrdering:
+
+    def test_decode_returns_dict(self, gans):
+        order = gans._rule_to_order('lf')
+        result = gans._decode(order)
+        assert isinstance(result, dict)
+        assert 'scheduled_duration' in result
+
+    def test_decode_fitness_positive(self, gans):
+        order = gans._rule_to_order('lf')
+        f = gans._decode_fitness(order)
+        assert f > 0
+
+    def test_get_schedule_times_after_decode(self, gans):
+        order = gans._rule_to_order('lf')
+        gans._decode(order)
+        times = gans._get_schedule_times()
+        assert isinstance(times, dict)
+        assert len(times) == gans._n
+        for a, (s, e) in times.items():
+            assert e >= s, f"End time {e} < start time {s} for {a}"
+
+    def test_order_from_schedule_is_permutation(self, gans):
+        order = gans._rule_to_order('lf')
+        gans._decode(order)
+        times = gans._get_schedule_times()
+        derived = gans._order_from_schedule(times)
+        assert sorted(derived) == list(range(gans._n))
+
+    def test_fbi_returns_valid_fitness_and_order(self, gans):
+        order = gans._rule_to_order('lf')
+        fitness, best_order = gans._fbi(order)
+        assert isinstance(fitness, (int, float))
+        assert fitness > 0
+        assert sorted(best_order) == list(range(gans._n))
+
+    def test_fbi_fitness_le_plain_decode(self, gans):
+        """FBI should not worsen fitness compared to a plain forward decode."""
+        order = gans._rule_to_order('lf')
+        plain_fitness = gans._decode_fitness(order)
+        fbi_fitness, _ = gans._fbi(order)
+        assert fbi_fitness <= plain_fitness + 1e-6, (
+            f"FBI worsened fitness: {fbi_fitness} > {plain_fitness}"
+        )
+
+    def test_evaluate_with_fbi_structure(self, gans):
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_with_fbi(order)
+        assert 'order' in ind and 'fitness' in ind
+        assert sorted(ind['order']) == list(range(gans._n))
+        assert ind['fitness'] < math.inf
+
+
+# =============================================================================
+# 4a. Dense genes
+# =============================================================================
+
+class TestDenseActivities:
+
+    def test_returns_list(self, gans):
+        order = gans._rule_to_order('lf')
+        gans._decode(order)
+        times = gans._get_schedule_times()
+        genes = gans._dense_activities(order, times)
+        assert isinstance(genes, list)
+
+    def test_genes_are_frozensets(self, gans):
+        order = gans._rule_to_order('lf')
+        gans._decode(order)
+        times = gans._get_schedule_times()
+        genes = gans._dense_activities(order, times)
+        for g in genes:
+            assert isinstance(g, frozenset)
+
+    def test_genes_activities_in_activity_set(self, gans):
+        """Every activity in every dense gene must be a known activity."""
+        act_set = set(gans._activities)
+        order = gans._rule_to_order('lf')
+        gans._decode(order)
+        times = gans._get_schedule_times()
+        genes = gans._dense_activities(order, times)
+        for gene in genes:
+            for a in gene:
+                assert a in act_set
+
+    def test_genes_non_overlapping(self, gans):
+        """Dense genes must be non-overlapping (each activity in at most one gene)."""
+        order = gans._rule_to_order('lf')
+        gans._decode(order)
+        times = gans._get_schedule_times()
+        genes = gans._dense_activities(order, times)
+        seen: set = set()
+        for gene in genes:
+            assert gene.isdisjoint(seen), "Dense gene activities overlap"
+            seen |= gene
+
+    def test_zero_threshold_returns_no_genes(self, gans):
+        """A threshold of 0 means v_t < 0 is never satisfied → no dense genes."""
+        original_threshold = gans.resource_threshold
+        gans.resource_threshold = 0.0
+        order = gans._rule_to_order('lf')
+        gans._decode(order)
+        times = gans._get_schedule_times()
+        genes = gans._dense_activities(order, times)
+        gans.resource_threshold = original_threshold
+        assert genes == []
+
+
+# =============================================================================
+# 4b. Crossover operators
+# =============================================================================
+
+class TestCrossoverA:
+
+    def _make_pair(self, gans):
+        o1 = gans._rule_to_order('lf')
+        o2 = gans._rule_to_order('es')
+        p1 = gans._evaluate_no_fbi(o1)
+        p2 = gans._evaluate_no_fbi(o2)
+        return p1, p2
+
+    def test_returns_individual(self, gans):
+        p1, p2 = self._make_pair(gans)
+        child = gans._crossover_A(p1, p2)
+        assert 'order' in child and 'fitness' in child
+
+    def test_child_is_valid_permutation(self, gans):
+        p1, p2 = self._make_pair(gans)
+        child = gans._crossover_A(p1, p2)
+        assert sorted(child['order']) == list(range(gans._n))
+
+    def test_child_fitness_is_positive(self, gans):
+        p1, p2 = self._make_pair(gans)
+        child = gans._crossover_A(p1, p2)
+        assert child['fitness'] > 0
+        assert child['fitness'] < math.inf
+
+    def test_child_decodes_without_error(self, gans):
+        """Crossover A child order must decode to a finite-duration schedule."""
+        p1, p2 = self._make_pair(gans)
+        child = gans._crossover_A(p1, p2)
+        result = gans._decode(child['order'])
+        assert result['scheduled_duration'] > 0
+
+
+class TestCrossoverB:
+
+    def _make_pair(self, gans):
+        o1 = gans._rule_to_order('lf')
+        o2 = gans._rule_to_order('grpw')
+        p1 = gans._evaluate_no_fbi(o1)
+        p2 = gans._evaluate_no_fbi(o2)
+        return p1, p2
+
+    def test_returns_individual(self, gans):
+        p1, p2 = self._make_pair(gans)
+        child = gans._crossover_B(p1, p2)
+        assert 'order' in child and 'fitness' in child
+
+    def test_child_is_valid_permutation(self, gans):
+        p1, p2 = self._make_pair(gans)
+        child = gans._crossover_B(p1, p2)
+        assert sorted(child['order']) == list(range(gans._n))
+
+    def test_child_fitness_is_positive(self, gans):
+        p1, p2 = self._make_pair(gans)
+        child = gans._crossover_B(p1, p2)
+        assert child['fitness'] > 0
+        assert child['fitness'] < math.inf
+
+    def test_child_decodes_without_error(self, gans):
+        """Crossover B child order must decode to a finite-duration schedule."""
+        p1, p2 = self._make_pair(gans)
+        child = gans._crossover_B(p1, p2)
+        result = gans._decode(child['order'])
+        assert result['scheduled_duration'] > 0
+
+    def test_fallback_to_crossover_a_no_genes(self, gans):
+        """When threshold is very high (no dense genes), crossover B must
+        still produce a valid individual via fallback to crossover A."""
+        original = gans.resource_threshold
+        gans.resource_threshold = 1e9
+        o1 = gans._rule_to_order('lf')
+        o2 = gans._rule_to_order('es')
+        p1 = gans._evaluate_no_fbi(o1)
+        p2 = gans._evaluate_no_fbi(o2)
+        child = gans._crossover_B(p1, p2)
+        gans.resource_threshold = original
+        assert sorted(child['order']) == list(range(gans._n))
+
+
+# =============================================================================
+# 4c. Mutation
+# =============================================================================
+
+class TestMutate:
+
+    def test_returns_individual(self, gans):
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_no_fbi(order)
+        mutant = gans._mutate(ind)
+        assert 'order' in mutant and 'fitness' in mutant
+
+    def test_mutant_is_valid_permutation(self, gans):
+        random.seed(42)
+        expected = set(range(gans._n))
+        for _ in range(10):
+            order = gans._rule_to_order('random')
+            ind = gans._evaluate_no_fbi(order)
+            mutant = gans._mutate(ind)
+            assert set(mutant['order']) == expected
+
+    def test_mutant_fitness_is_finite(self, gans):
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_no_fbi(order)
+        mutant = gans._mutate(ind)
+        assert mutant['fitness'] < math.inf
+
+    def test_mutant_decodes_without_error(self, gans):
+        """Mutant order must decode to a finite-duration schedule."""
+        random.seed(7)
+        for _ in range(5):
+            order = gans._rule_to_order('lf')
+            ind = gans._evaluate_no_fbi(order)
+            mutant = gans._mutate(ind)
+            result = gans._decode(mutant['order'])
+            assert result['scheduled_duration'] > 0
+
+
+# =============================================================================
+# 4d. Initial population and parent selection
+# =============================================================================
+
+class TestInitialPopulation:
+
+    def test_population_size(self, gans):
+        pop = gans._build_initial_population()
+        assert len(pop) == gans.pop_size
+
+    def test_all_individuals_valid_permutations(self, gans):
+        pop = gans._build_initial_population()
+        expected = set(range(gans._n))
+        for i, ind in enumerate(pop):
+            assert set(ind['order']) == expected, \
+                f"Individual {i} not a valid permutation"
+            assert len(ind['order']) == gans._n
+
+    def test_all_individuals_have_finite_fitness(self, gans):
+        pop = gans._build_initial_population()
+        for ind in pop:
+            assert ind['fitness'] < math.inf
+            assert ind['fitness'] > 0
+
+    def test_population_elements_are_dicts(self, gans):
+        pop = gans._build_initial_population()
+        for ind in pop:
+            assert isinstance(ind, dict)
+            assert 'order' in ind
+            assert 'fitness' in ind
+
+
+class TestSelectParents:
+
+    def test_always_includes_best(self, gans):
+        pop = gans._build_initial_population()
+        best_fitness = min(ind['fitness'] for ind in pop)
+        random.seed(1)
+        parents = gans._select_parents(pop)
+        assert any(p['fitness'] <= best_fitness + 1e-9 for p in parents)
+
+    def test_parents_size_bounded(self, gans):
+        pop = gans._build_initial_population()
+        parents = gans._select_parents(pop)
+        assert len(parents) <= gans.parents_size
+        assert len(parents) >= 1
+
+    def test_parents_are_subset_of_population(self, gans):
+        pop = gans._build_initial_population()
+        parents = gans._select_parents(pop)
+        pop_fitness_set = {ind['fitness'] for ind in pop}
+        for p in parents:
+            assert p['fitness'] in pop_fitness_set
+
+
+# =============================================================================
+# 4e. Neighbourhood operators
+# =============================================================================
+
+class TestNeighborhoodNA:
+
+    def test_returns_tuple(self, gans):
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_no_fbi(order)
+        _result, evals = gans._na_neighbor(ind)
+        assert isinstance(evals, int)
+        assert evals >= 1
+
+    def test_neighbor_or_none(self, gans):
+        """_na_neighbor returns either a valid Individual or None."""
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_no_fbi(order)
+        neighbor, _ = gans._na_neighbor(ind)
+        if neighbor is not None:
+            assert 'order' in neighbor and 'fitness' in neighbor
+            assert sorted(neighbor['order']) == list(range(gans._n))
+
+    def test_neighbor_fitness_finite_when_not_none(self, gans):
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_no_fbi(order)
+        neighbor, _ = gans._na_neighbor(ind)
+        if neighbor is not None:
+            assert neighbor['fitness'] < math.inf
+
+    def test_neighbor_decodes_without_error_when_not_none(self, gans):
+        """NA neighbor order must decode to a finite-duration schedule."""
+        random.seed(3)
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_no_fbi(order)
+        for _ in range(5):
+            neighbor, _ = gans._na_neighbor(ind)
+            if neighbor is None:
+                continue
+            result = gans._decode(neighbor['order'])
+            assert result['scheduled_duration'] > 0
+
+
+class TestNeighborhoodNB:
+
+    def test_returns_tuple(self, gans):
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_no_fbi(order)
+        _result, evals = gans._nb_neighbor(ind)
+        assert isinstance(evals, int)
+        assert evals >= 0
+
+    def test_neighbor_or_none(self, gans):
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_no_fbi(order)
+        neighbor, _ = gans._nb_neighbor(ind)
+        if neighbor is not None:
+            assert 'order' in neighbor and 'fitness' in neighbor
+            assert sorted(neighbor['order']) == list(range(gans._n))
+
+    def test_neighbor_fitness_finite_when_not_none(self, gans):
+        order = gans._rule_to_order('lf')
+        ind = gans._evaluate_no_fbi(order)
+        neighbor, _ = gans._nb_neighbor(ind)
+        if neighbor is not None:
+            assert neighbor['fitness'] < math.inf
+
+
+# =============================================================================
+# 4f. Adaptive block size and instance classification
+# =============================================================================
+
+class TestUpdateBlockSize:
+
+    def test_size_decreases_on_high_empty_rate(self, gans):
+        """Block size must shrink if > 50% of recent neighbors were empty."""
+        gans._block_size = 5
+        gans._empty_block_history = [True] * 20
+        gans._update_block_size()
+        assert gans._block_size < 5
+
+    def test_size_increases_on_low_empty_rate(self, gans):
+        """Block size must grow if < 20% of recent neighbors were empty."""
+        gans._block_size = 3
+        gans._empty_block_history = [False] * 20
+        gans._update_block_size()
+        assert gans._block_size >= 3
+
+    def test_no_change_when_history_short(self, gans):
+        gans._block_size = 4
+        gans._empty_block_history = [True] * 5  # less than window=20
+        original = gans._block_size
+        gans._update_block_size()
+        assert gans._block_size == original
+
+
+class TestAssignSubsetParams:
+
+    def test_subset1_low_sigma(self, gans):
+        """A fitness close to CPM duration → subset 1 (high stall, low ns)."""
+        cpm = gans._cpm_duration
+        gans._assign_subset_params(cpm * 1.05)  # sigma ≈ 0.05 < sigma1=0.2
+        assert gans.ga_stall_limit == 80
+        assert gans.ns_steps == 50
+
+    def test_subset3_high_sigma(self, gans):
+        """A fitness far above CPM duration → subset 3 (low stall, high ns)."""
+        cpm = gans._cpm_duration
+        gans._assign_subset_params(cpm * 2.0)   # sigma ≈ 1.0 > sigma2=0.6
+        assert gans.ga_stall_limit == 20
+        assert gans.ns_steps == 300
+
+    def test_subset2_medium_sigma(self, gans):
+        """A fitness moderately above CPM → subset 2."""
+        cpm = gans._cpm_duration
+        gans._assign_subset_params(cpm * 1.4)   # sigma ≈ 0.4, between 0.2 and 0.6
+        assert gans.ga_stall_limit == 50
+        assert gans.ns_steps == 150
+
+
+# =============================================================================
+# 5. End-to-end smoke tests
+# =============================================================================
+
+class TestRun:
+
+    @pytest.fixture(scope='class')
+    def run_results(self, pert):
+        """Run GANS once with a tiny budget; reuse across the class."""
+        g = RCPSPHybridGANS(
+            pert,
+            pop_size=5,
+            lambda_max=200,
+            ga_stall_limit=8,
+            ns_steps=5,
+            block_size=3,
+            seed=42,
+            verbose=False,
+        )
+        best, log = g.run()
+        return g, best, log
+
+    def test_run_returns_best_and_log(self, run_results):
+        _, best, log = run_results
+        assert isinstance(best, dict)
+        assert isinstance(log, list)
+
+    def test_best_has_required_keys(self, run_results):
+        _, best, _ = run_results
+        assert 'order' in best
+        assert 'fitness' in best
+
+    def test_best_order_is_valid_permutation(self, run_results):
+        g, best, _ = run_results
+        assert sorted(best['order']) == list(range(g._n))
+
+    def test_best_fitness_is_finite_and_positive(self, run_results):
+        _, best, _ = run_results
+        assert best['fitness'] > 0
+        assert best['fitness'] < math.inf
+
+    def test_log_is_non_empty(self, run_results):
+        _, _, log = run_results
+        assert len(log) > 0
+
+    def test_log_entry_keys(self, run_results):
+        _, _, log = run_results
+        expected_keys = {'n_evals', 'best', 'event', 'ga_stall', 'n_ns_activations'}
+        for entry in log:
+            assert expected_keys.issubset(entry.keys())
+
+    def test_log_evals_monotonic(self, run_results):
+        _, _, log = run_results
+        evals = [e['n_evals'] for e in log]
+        for i in range(1, len(evals)):
+            assert evals[i] >= evals[i - 1], \
+                f"n_evals decreased at entry {i}: {evals[i-1]} → {evals[i]}"
+
+    def test_log_best_monotonic(self, run_results):
+        """Best fitness in log must be non-increasing over time."""
+        _, _, log = run_results
+        bests = [e['best'] for e in log]
+        for i in range(1, len(bests)):
+            assert bests[i] <= bests[i - 1] + 1e-9, \
+                f"Best fitness increased at entry {i}: {bests[i-1]} → {bests[i]}"
+
+    def test_get_best_schedule_returns_dict(self, run_results):
+        g, best, _ = run_results
+        result = g.get_best_schedule(best)
+        assert isinstance(result, dict)
+        assert 'scheduled_duration' in result
+
+    def test_get_best_schedule_duration_positive(self, run_results):
+        """Re-decoded schedule must have a positive finite duration."""
+        g, best, _ = run_results
+        result = g.get_best_schedule(best)
+        assert result['scheduled_duration'] > 0
+        assert result['scheduled_duration'] < math.inf
+
+    def test_get_best_activity_list_length(self, run_results):
+        g, best, _ = run_results
+        act_list = g.get_best_activity_list(best)
+        assert len(act_list) == g._n
+
+    def test_get_best_activity_list_types(self, run_results):
+        g, best, _ = run_results
+        act_list = g.get_best_activity_list(best)
+        assert all(isinstance(name, str) for name in act_list)
+
+    def test_get_convergence_summary_keys(self, run_results):
+        g, _, log = run_results
+        summary = g.get_convergence_summary(log)
+        expected = {
+            'n_evals', 'best_duration', 'initial_best',
+            'improvement', 'n_ns_activations', 'final_stall',
+        }
+        assert expected == set(summary.keys())
+
+    def test_convergence_improvement_non_negative(self, run_results):
+        g, _, log = run_results
+        summary = g.get_convergence_summary(log)
+        assert summary['improvement'] >= -1e-9, \
+            f"Unexpected regression: {summary['improvement']}"
+
+    def test_convergence_summary_empty_log(self, run_results):
+        g, _, _ = run_results
+        assert g.get_convergence_summary([]) == {}
+
+    def test_get_best_schedule_schedules_all_activities(self, run_results):
+        """Re-decoded schedule must report all activities as completed."""
+        g, best, _ = run_results
+        result = g.get_best_schedule(best)
+        assert result.get('n_completed', 0) == g._n
+
+
+# =============================================================================
+# Run standalone
+# =============================================================================
+
+if __name__ == '__main__':
+    import subprocess
+    sys.exit(subprocess.call(['pytest', __file__, '-v']))

--- a/tests/unit_tests/CPM/test_gga.py
+++ b/tests/unit_tests/CPM/test_gga.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for gga.py - RCPSPGraphGeneticAlgorithm.
+
+Run from repo root:
+    pytest tests/unit_tests/CPM/test_gga.py -v
+"""
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from src.CPM.gga import PRIORITY_RULES, RCPSPGraphGeneticAlgorithm  # noqa: E402
+from src.CPM.pert import Pert  # noqa: E402
+
+
+CPM_DIR = REPO_ROOT / 'tests' / 'unit_tests' / 'CPM'
+JSON_PATH = str(CPM_DIR / 'j301_1.json')
+SCHEMA = str(REPO_ROOT / 'src' / 'CPM' / 'outage_schema.json')
+
+
+@pytest.fixture(scope='module')
+def pert():
+    p = Pert.from_json_file(JSON_PATH, schema_path=SCHEMA)
+    p.generateInfo()
+    return p
+
+
+@pytest.fixture()
+def gga(pert):
+    return RCPSPGraphGeneticAlgorithm(
+        pert,
+        ne=5,
+        n_gen=3,
+        restart_threshold=2,
+        seed=0,
+        verbose=False,
+    )
+
+
+def test_zero_lag_matches_cpm_early_starts(gga, pert):
+    starts = gga._lags_to_start_times([0.0] * len(gga._arcs))
+    for act in gga._activities:
+        assert math.isclose(starts[act], pert.infoDict[act]['es'], abs_tol=1e-9)
+
+
+def test_corrected_lags_preserve_feasible_start_times(gga):
+    lags = [float(i % 4) * 0.25 for i in range(len(gga._arcs))]
+    starts = gga._lags_to_start_times(lags)
+    corrected = gga._correct_aon_lag(starts)
+    restored = gga._lags_to_start_times(corrected)
+
+    for act in gga._activities:
+        assert math.isclose(restored[act], starts[act], abs_tol=1e-9)
+
+
+def test_priority_seed_population_uses_priority_orders(pert):
+    gga = RCPSPGraphGeneticAlgorithm(
+        pert,
+        ne=5,
+        n_gen=0,
+        seed=0,
+        verbose=False,
+    )
+
+    expected = []
+    for rule in PRIORITY_RULES[:gga.ne]:
+        pert.priorities = None
+        out = pert.calculateSerialScheduleWithResources(priority_rule=rule)
+        expected.append(out['scheduled_duration'] - 2)
+
+    pool = gga._build_initial_population()
+    fitnesses = [ind['fitness'] for ind in pool]
+
+    assert sorted(fitnesses) == sorted(expected)
+    assert len(set(fitnesses)) > 1
+
+
+def test_run_returns_feasible_winner(gga):
+    winner, log = gga.run()
+    result = gga.get_best_schedule(winner)
+
+    assert len(log) == gga.n_gen + 1
+    assert math.isfinite(winner['fitness'])
+    assert result['n_completed'] == result['n_activities']
+    assert math.isclose(
+        result['scheduled_duration'] - 2,
+        winner['fitness'],
+        abs_tol=1e-9,
+    )

--- a/tests/unit_tests/CPM/tests
+++ b/tests/unit_tests/CPM/tests
@@ -15,4 +15,8 @@
   type = 'RavenPython'
   input = 'test_rcpsp_alns.py'
  [../]
+ [./test_gans]
+  type = 'RavenPython'
+  input = 'test_gans.py'
+ [../]
 []

--- a/tests/unit_tests/CPM/tests
+++ b/tests/unit_tests/CPM/tests
@@ -1,22 +1,32 @@
 [Tests]
+
  [./utils]
   type = 'RavenPython'
   input = 'CPM.py'
  [../]
+
  [./test_psplib]
   type = 'RavenPython'
   input = 'test_psplib.py'
  [../]
+
  [./test_ga]
   type = 'RavenPython'
   input = 'test_ga.py'
  [../]
-[./test_ga]
+
+ [./test_alns]
   type = 'RavenPython'
   input = 'test_rcpsp_alns.py'
  [../]
+
  [./test_gans]
   type = 'RavenPython'
   input = 'test_gans.py'
+ [../]
+
+ [./test_gga]
+  type = 'RavenPython'
+  input = 'test_gga.py'
  [../]
 []


### PR DESCRIPTION
--------
Pull Request Description
--------
# Heuristic Optimizers for RCPSP

This document consolidates the optimizer change notes. It covers the activity-list GA, graph-based GA (GGA), hybrid GA + neighbourhood
search (GANS), integration runners, convergence plotting, stopping criteria, and
test coverage.

## Optimizer Inventory

| Optimizer | File | Representation | Main idea |
|-----------|------|----------------|-----------|
| Standard GA | `src/CPM/ga.py` | Activity-list chromosome | DEAP-based GA with priority-rule seeding, configurable crossover/mutation, optional FBF improvement, convergence plotting, and stopping criteria |
| GGA | `src/CPM/gga.py` | AON lag vector | Micro-GA based on graph lag chromosomes and the six graph/day/activity-list operators from Liu et al. |
| GANS | `src/CPM/gans.py` | Activity-list chromosome | Hybrid GA with dense-gene crossovers, FBI improvement, adaptive neighbourhood search, and tabu logic |
| ALNS benchmark comparison | `src/CPM/gans_test.py` | Existing ALNS driver | Side-by-side benchmark comparison with GA and GANS |

All optimizers use the same fitness convention:

```python
fitness = out['scheduled_duration'] - 2
```

where `out` is returned by the PERT/RCPSP scheduling routines.

## References

- Kolisch, R. and Hartmann, S. (1999). Heuristic Algorithms for Solving the
  Resource-Constrained Project Scheduling Problem.
- Liu, Y., Liu, X., and Huang, L. (2025). A graph-based genetic algorithm for
  resource-constrained project scheduling problems. SSRN 5851447.
- Goncharov, E.N. (2025). A hybrid heuristic algorithm for the
  resource-constrained project scheduling problem. arXiv:2502.18330v2.

## Standard GA (`src/CPM/ga.py`)

### Representation

The standard GA uses an activity-list chromosome:

```python
order = [i0, i1, ..., iN-1]
```

Each value is an index into `self._activities`. The chromosome is decoded by
converting the integer list to activities and passing the result to:

```python
pert.calculateSerialScheduleWithResources(_ordered=ordered_acts)
```

### Existing GA Features

- Priority-rule seeded initial population.
- Configurable population size, generations, crossover probability, mutation
  probability, Hall-of-Fame size, random seed, and verbosity.
- Crossover choices:
  - `one_point`
  - `two_point`
  - `uniform_order`
- Mutation choices:
  - `swap`
  - `adjacent_swap`
  - `insertion_window`
  - `consensus_reorder`
- Optional Forward-Backward-Forward improvement:
  - final polishing pass when `fb_improvement=True`,
  - optional periodic in-run application with `fb_freq > 0`.

### Consensus-Reorder Mutation

The `consensus_reorder` mutation was added as a consensus-guided unary mutation:

```python
ga = RCPSPGeneticAlgorithm(
    pert,
    mutation="consensus_reorder",
    n_random=12,
)
```

The mutation:

- selects a local interior chromosome window,
- samples precedence-feasible reference orderings,
- computes a consensus score for each gene in the selected window using average
  reference positions,
- reorders only that window by consensus ranking,
- repairs the full chromosome to restore precedence feasibility.

Supporting additions:

- `self._consensus_library`
- `self._consensus_position_maps`
- `_build_consensus_library(...)`
- `_repair_chromosome(...)`

`_repair_chromosome(...)` centralizes precedence repair by converting the chromosome
to `(Activity, rank)` pairs, calling `pert.reorder_by_dependencies(...)`, and mapping
the repaired result back to integer genes. It is used by both `_mutate_swap()` and
`_mutate_consensus_reorder()`.

The constructor now accepts:

```python
n_random: int = 8
```

This controls how many random precedence-feasible chromosomes are added to the
consensus reference library.

### Convergence Plotting

`plot_convergence(...)` was added to visualize the `Logbook` returned by `run()`:

```python
fig, ax = ga.plot_convergence(
    log,
    filename="ga_convergence.png",
    show=False,
)
```

The plot can include:

- generation minimum fitness,
- cumulative best-so-far,
- population average,
- average +/- one standard-deviation band,
- optional population maximum.

The method supports saving to file, headless plotting, and drawing into an existing
matplotlib axis.

### Stopping Criteria

The GA now supports search-informed convergence and stopping criteria:

```python
RCPSPGeneticAlgorithm(
    pert,
    target_fitness=None,
    max_evals=None,
    stall_generations=None,
    stall_tolerance=1e-9,
    fitness_std_tol=None,
    std_generations=1,
    max_unique_schedules=None,
)
```

Supported stop reasons:

| Stop reason | Meaning |
|-------------|---------|
| `target_fitness` | Hall-of-Fame best fitness is <= `target_fitness` |
| `max_evals` | GA fitness-evaluation budget is exhausted |
| `stall_generations` | best-so-far did not improve for the configured stall window |
| `fitness_std_tol` | population fitness standard deviation stayed below tolerance long enough |
| `max_unique_schedules` | enough unique decoded start-time schedules were observed |
| `max_generations` | no optional stopping criterion fired before `n_gen` |

Validation was added for invalid stopping inputs:

- `max_evals < pop_size`
- nonpositive `stall_generations`
- negative `stall_tolerance`
- negative `fitness_std_tol`
- nonpositive `std_generations`
- nonpositive `max_unique_schedules`

`max_evals` counts calls to `_evaluate()` and its Serial SGS decode. FBF
local-improvement decode calls are not counted, so strict evaluation-budget
experiments should use:

```python
fb_improvement=False
```

### Expanded GA Logging

The `run()` logbook was expanded from generation statistics only to:

- `gen`
- `nevals`
- `evals`
- `best`
- `stall`
- `unique_schedules`
- `stop_reason`
- `min`
- `avg`
- `std`
- `max`

`get_convergence_summary(...)` now returns:

- `n_gen`
- `best_duration`
- `initial_best`
- `improvement`
- `final_avg`
- `final_std`
- `n_evals`
- `n_unique_schedules`
- `stop_reason`

## Graph Genetic Algorithm (`src/CPM/gga.py`)

### Overview

GGA implements a graph-based micro-GA for RCPSP using an Activity-on-Node lag-based
chromosome rather than the activity-list chromosome used by `ga.py`.

The initial implementation added:

- `src/CPM/gga.py`
- `src/CPM/gga_test.py`
- `doc/plan_gga.md`

The implementation follows the graph-based GA from Liu et al. (2025).

### Chromosome

For each project-network arc `(i -> j)`:

```text
lambda(i, j) = S(j) - S(i) - d(i) >= 0
```

where:

- `S(.)` is activity start time in hours from project start,
- `d(i)` is activity duration,
- lags are stored as a flat `List[float]`,
- arcs are enumerated once from `pert.forwardDict`.

An individual is a plain Python dictionary:

```python
{"lags": List[float], "fitness": float}
```

GGA does not use DEAP. The micro-GA operates with plain dict individuals and
`min(pool, key=...)` style selection.

### Conversion Pipeline

Each genetic operation ultimately decodes lag vectors through:

```text
lags
  -> _lags_to_start_times(lags)
  -> _start_times_to_activity_order()
  -> calculateSerialScheduleWithResources(_ordered=...)
  -> read activity.startTime datetimes
  -> _correct_aon_lag(actual_starts)
```

`_improve(lags)` runs this full pipeline and returns:

```python
(makespan, corrected_lags)
```

Activity-list operators build orderings directly, so they use
`_evaluate_activity_order(order)` instead of forcing position indices through the lag
pipeline.

### Class Interface

```python
RCPSPGraphGeneticAlgorithm(
    pert,
    ne=5,
    n_gen=500,
    restart_threshold=50,
    rho=0.2,
    seed=42,
    verbose=True,
)
```

Constructor state includes:

- `_activities`
- `_act_to_idx`
- `_arcs`
- `_arc_to_idx`
- `_topo`
- `_topo_idx`
- `_durations`
- `_dummy_acts`
- `_cpm_duration`

If `pert.nxgraph` is not available, a Kahn BFS fallback computes the topological
order from `forwardDict`.

### Operators

| Paper algorithm | Method | Description |
|-----------------|--------|-------------|
| Alg 2 | `_select_frozen_block(winner)` | Selects predecessor or successor subgraph blocks and excludes high-ranked nodes by degree, duration, and random tie-break |
| Alg 3 | `_lag_crossover(p1, p2, frozen)` | Exchanges lag values while preserving frozen winner structure |
| Alg 4 | `_lag_mutation(ind, frozen)` | Shifts incoming lags of one non-frozen activity by a scalar delta |
| Alg 5 | `_day_form_crossover(winner, challenger, frozen)` | Crosses start-time vectors, restores frozen activities, then improves |
| Alg 6 | `_day_form_mutation(ind)` | Shifts one activity earlier and improves |
| Alg 7 | `_activity_list_crossover(winner, challenger, frozen)` | Builds activity-list offspring from parent orderings with precedence repair |
| Alg 8 | `_activity_list_mutation(ind, frozen)` | Relocates an activity inside a feasible predecessor/successor window |

### Main Loop

The GGA main loop:

1. Builds an elite pool with priority-rule seeds, zero-lag individuals, and random
   lag individuals.
2. Selects a frozen block from the current winner.
3. Produces six offspring, one per graph/day/activity-list operator.
4. Merges elite and offspring, sorts by fitness, and keeps the best `ne`.
5. Updates the all-time winner and stall count.
6. Restarts the pool when `stall >= restart_threshold`.

Log entries contain:

```python
{"gen": int, "best": float, "pool_best": float, "stall": int, "restart": bool}
```

Result helpers:

```python
get_best_schedule(winner) -> dict
get_best_activity_list(winner) -> List[str]
get_convergence_summary(log) -> dict
```

### GGA Improvements on 2026-05-06

The GGA was later reviewed against `doc/plan_gga.md` and
`src/CPM/refs/graph_based_GA.pdf`. Improvements included:

- priority-rule seeding now produces real priority orders decoded by Serial SGS,
  rather than repeatedly seeding equivalent CPM-lag schedules,
- incomplete decoded schedules are penalized,
- restart handling merges fresh elite solutions with the previous winner,
- lag-form crossover swaps incoming lag bundles,
- day-form crossover supports four variants,
- backward frozen-frontier handling includes predecessors,
- activity-list mutation uses transitive successor information to preserve
  precedence feasibility,
- unit coverage was added and `test_gga.py` was registered in the CPM test manifest.

## Hybrid GA + Neighbourhood Search (`src/CPM/gans.py`)

### Overview

GANS implements the hybrid Genetic Algorithm + Neighbourhood Search method from
Goncharov (2025). It was added as a third RCPSP metaheuristic alongside the standard
GA and GGA.

Initial files:

- `src/CPM/gans.py`
- `src/CPM/gans_test.py`
- `doc/plan_gans.md`

GANS does not use DEAP. Individuals are plain dictionaries:

```python
{"order": List[int], "fitness": float}
```

### Resource Ranking

Resources are ranked by utilization load:

```text
load_k = sum_j(r_jk * p_j) / (R_k * T_cpm)
```

where:

- `r_jk` is demand of activity `j` for resource `k`,
- `p_j` is activity duration,
- `R_k` is capacity of resource `k`,
- `T_cpm` is unconstrained CPM project duration.

At each neighbourhood-search restart, one weight vector is sampled from:

```python
_WEIGHT_SETS = [
    (1.0, 0.8, 0.6, 0.4),
    (1.0, 0.9, 0.8, 0.7),
    (1.0, 1.0, 1.0, 1.0),
]
```

Weights are stored in `self._resource_weights`, keyed by skill ID.

### Dense Genes

Dense genes identify the most resource-intensive time intervals in a schedule:

1. Build an event-time grid from all activity start/end times.
2. For each interval, compute weighted residual capacity:

   ```text
   v_t = sum_k (R_k - used_k) * w_k / R_k
   ```

3. Intervals with `v_t < resource_threshold` are dense genes.
4. Greedily select non-overlapping intervals ordered by smallest residual capacity.

If resource metadata is unavailable, the implementation degrades gracefully to an
activity-count utilization proxy.

### GANS Operators

#### Crossover A

`_crossover_A(p1, p2)` performs dense-gene greedy merge:

- decode parents,
- collect dense genes,
- merge and sort genes by residual-capacity score,
- append activities from the parent that owns each gene,
- fill the remaining activities from the shorter-duration parent,
- repair precedence,
- evaluate with FBI.

#### Crossover B

`_crossover_B(p1, p2)` performs network-based segment swap:

- decode parents,
- build schedule graphs from tight project-network arcs,
- select best dense genes,
- find outgoing BFS network spans in the other parent,
- swap the corresponding chromosome segment,
- repair and evaluate with FBI.

If either parent has no dense genes, Crossover B falls back to Crossover A.

#### Mutation

`_mutate(ind)` applies two mutation phases followed by FBI:

- swap two non-dummy positions when precedence allows,
- relocate one non-dummy activity inside its feasible insertion window,
- apply FBI once at the end.

#### FBI

`_fbi(order)` performs Forward-Backward-Forward improvement:

```text
forward SGS(order)
backward SGS(reversed(order1))
forward SGS(order2)
return best of the three
```

FBI is invoked after every crossover and mutation. It accounts for three SGS calls
per invocation in GANS evaluation budgeting.

### Neighbourhood Search

GANS activates neighbourhood search when the GA stalls.

#### NA Neighbour

`_na_neighbor(ind)`:

- decodes the individual,
- selects a random non-dummy core activity,
- creates a time-near block around the core,
- removes the block from the order,
- reinserts block activities at random feasible positions,
- repairs and applies FBI.

Block size adapts using a 20-call history of empty-block events.

#### NB Neighbour

`_nb_neighbor(ind)`:

- creates a block around a selected core activity,
- splits the activity list around the core,
- reorders the block with a greedy randomized GRASP-style parallel SGS,
- assembles the result,
- repairs and applies FBI.

#### GRASP Ordering

`_grasp_parallel_sgs(block_acts, used_resources)` scores candidate activities by:

```text
sum_k w_k * r_jk / R_k
```

It builds a restricted candidate list of size `alpha = 3`, selects randomly from
that list, and repeats until the block is ordered.

### Sigma-Based Instance Classification

After the initial population is built:

```text
sigma = (best_fitness - T_cpm) / T_cpm
```

| Sigma range | Subset | `ga_stall_limit` | `ns_steps` |
|-------------|--------|------------------|------------|
| `< 0.2` | easy | 80 | 50 |
| `0.2 - 0.6` | medium | 50 | 150 |
| `> 0.6` | hard | 20 | 300 |

This shifts more effort toward neighbourhood search for harder instances.

### Class Interface

```python
RCPSPHybridGANS(
    pert,
    pop_size=60,
    lambda_max=50_000,
    ga_stall_limit=50,
    ns_steps=200,
    block_size=6,
    resource_threshold=0.75,
    sigma1=0.2,
    sigma2=0.6,
    parents_size=10,
    seed=42,
    verbose=True,
)
```

Constructor state includes:

- `_activities`
- `_act_to_idx`
- `_dummy_acts`
- `_topo_idx`
- `_skill_ids`
- `_skill_capacity`
- `_activity_demand`
- `_cpm_duration`
- `_resource_weights`
- `_block_size`
- `_empty_block_history`

### Main Loop

GANS proceeds until `n_evals >= lambda_max`:

1. Select parent set `Gamma_prime` from the population.
2. Choose two parents from `Gamma_prime`.
3. Produce a child using Crossover A or B.
4. If the child is not better than its parents, mutate it.
5. Update best solution and GA stall count.
6. Apply tournament replacement.
7. When GA stall reaches the limit, run alternating NA/NB neighbourhood search.
8. Reinject best solution, reset GA stall, and randomize resource weights.

Log entries contain:

```python
{
    "n_evals": int,
    "best": float,
    "event": str,
    "ga_stall": int,
    "n_ns_activations": int,
}
```

Result helpers:

```python
get_best_schedule(best) -> dict
get_best_activity_list(best) -> List[str]
get_convergence_summary(log) -> dict
```

### GANS Design Notes

- Plain Python dict individuals avoid DEAP overhead.
- FBI after every operator matches the GA(FBI) configuration in the reference.
- Crossover B falls back to Crossover A when dense-gene extraction fails.
- Resource-aware paths degrade gracefully when explicit resource metadata is missing.
- Kahn BFS topological sorting is used when `pert.nxgraph` is unavailable.
- The paper's Gimadi-style cumulative slack solver was not implemented; the simpler
  load-based resource ranking was used instead.

## Integration and Benchmark Drivers

### `src/CPM/ga_test.py`

The GA integration runner now supports:

- benchmark best-known result lookup from `benchmarks/best_results.json`,
- summary columns for `Best Known` and `GA-BK`,
- convergence plots saved per case,
- command-line configuration,
- stopping-criterion flags.

Useful commands:

```bash
python -m src.CPM.ga_test --case j30
python -m src.CPM.ga_test --max-evals 5000
python -m src.CPM.ga_test --stall-generations 25 --fitness-std-tol 0.01
python -m src.CPM.ga_test --target-best-known --case j30
```

General flags:

- `--case`
- `--pop-size`
- `--n-gen`
- `--cxpb`
- `--mutpb`
- `--seed`
- `--quiet`
- `--crossover`
- `--mutation`
- `--no-fb-improvement`
- `--fb-freq`
- `--no-plot`
- `--plot-dir`

Stopping flags:

- `--target-fitness`
- `--target-best-known`
- `--max-evals`
- `--stall-generations`
- `--stall-tolerance`
- `--fitness-std-tol`
- `--std-generations`
- `--max-unique-schedules`

Per-case output now includes:

- stop reason,
- generations executed,
- GA evaluation count,
- unique schedule count when enabled.

The final summary table includes:

- executed generations,
- evaluation count,
- stop reason,
- best-known result,
- GA gap to best-known result.

### `src/CPM/ga_test_hard.py`

The hard-case GA runner was updated with the same best-known result lookup used by
`ga_test.py`:

- `load_best_known_results()`
- `get_best_known_result(...)`
- `best_known`
- `ga_vs_best_known`

Filename mapping examples:

- `j12051_6.json -> j12051_6.sm`
- `j12031_10.json -> j12031_10.sm`
- `j301_1.json -> j301_1.sm`
- `j601_1.json -> j601_1.sm`
- `j901_1.json -> j901_1.sm`
- `j1201_1.json -> j1201_1.sm`

### `src/CPM/gga_test.py`

The GGA integration runner mirrors `ga_test.py` and reports:

- CPM unconstrained duration,
- best serial-SGS priority-rule baseline,
- best GGA duration,
- improvement over best-seeded initial population,
- improvement over best priority-rule baseline,
- restart count,
- final stall count,
- first 10 activities in the best activity list.

Default benchmark settings:

```python
ne=5
n_gen=200
restart_threshold=50
rho=0.2
seed=42
```

### `src/CPM/gans_test.py`

The GANS integration runner compares GA, ALNS, and GANS on each PSPLIB benchmark.

Default settings:

| Method | Default settings |
|--------|------------------|
| GA | `pop=30`, `n_gen=500`, `two_point` crossover |
| ALNS | `n_iter=2000`, destroy fraction `0.25`, hill-climbing acceptance |
| GANS | `pop=60`, `lambda_max=5000`, dense-gene A/B crossover |

Summary columns:

```text
Case  N  CPM(h)  BestRule  GA  ALNS  GANS  DeltaGA  DeltaALNS  DeltaGANS  NS#
```

`gans_test.py` subsumes `alns_test.py`; `alns_test.py` is retained for backward
compatibility.

## Test Coverage and Verification

### GA Unit Tests

Tests were added for:

- invalid stopping-criterion constructor values,
- presence of new stopping fields in the logbook,
- convergence plotting,
- target-fitness stopping,
- max-evaluation stopping,
- stall-generation stopping,
- unique-schedule budget tracking,
- updated convergence-summary keys.

Latest verified command:

```bash
MPLCONFIGDIR=/private/tmp/matplotlib-cache /Users/wangc/miniforge3/envs/logos_libs/bin/python -m pytest tests/unit_tests/CPM/test_ga.py -q
```

Result:

```text
112 passed
```

### GGA Verification

Initial GGA verification on `j301_1.json`, `seed=42`:

| Setting | Value |
|---------|-------|
| Network | 32 activities, 65 arcs |
| CPM duration | 40.0 h |
| Best priority-rule baseline | 46.0 h |
| GGA initial best | 51.0 h |
| GGA best after 30 generations | 49.0 h |
| Restarts in 30-generation run | 1 |

Invariant checks:

```text
zero-lag -> start times match CPM ES for all 32 activities
round-trip start-time preservation max error = 1.42e-14 h
```

### GANS Verification

Initial GANS verification on `j301_1.json`, `seed=42`, `pop=20`, `lambda_max=500`:

| Setting | Value |
|---------|-------|
| Network | 32 activities |
| CPM duration | 40.0 h |
| Best priority-rule baseline | 46.0 h |
| GANS initial best | 46.0 h |
| GANS best after 500 evaluations | 43.0 h |
| Improvement over initial best | 3.0 h |
| Sigma | 0.150, subset 1 |
| NS activations | 0 |

### Integration Smoke Runs

The GA runner was checked with:

```bash
/Users/wangc/miniforge3/envs/logos_libs/bin/python -m src.CPM.ga_test --help
/Users/wangc/miniforge3/envs/logos_libs/bin/python -m src.CPM.ga_test --case j30 --pop-size 5 --n-gen 20 --max-evals 5 --quiet --no-plot --no-fb-improvement
```

The smoke run stopped after the initial population with:

```text
stop_reason = max_evals
generations executed = 0
GA evaluations = 5
```

## Changed Files Summary

| File | Purpose |
|------|---------|
| `src/CPM/ga.py` | Standard GA, consensus mutation, convergence plotting, stopping criteria |
| `src/CPM/ga_test.py` | GA benchmark runner, best-known comparison, plots, CLI, stopping flags |
| `src/CPM/ga_test_hard.py` | Hard-case GA benchmark runner, best-known comparison |
| `src/CPM/gga.py` | Graph Genetic Algorithm implementation |
| `src/CPM/gga_test.py` | GGA integration runner |
| `src/CPM/gans.py` | Hybrid GA + Neighbourhood Search implementation |
| `src/CPM/gans_test.py` | GA/ALNS/GANS comparison runner |
| `doc/plan_gga.md` | GGA design plan |
| `doc/plan_gans.md` | GANS design plan |
| `tests/unit_tests/CPM/test_ga.py` | GA unit coverage for plotting and stopping |
| `tests/unit_tests/CPM/tests` | CPM test manifest updates, including `test_gga.py` |

## Practical Notes

- The standard GA remains the easiest optimizer to configure and compare across
  stopping criteria.
- GGA explores a different representation based on network lags and is useful for
  testing graph-structured operators.
- GANS is the heaviest optimizer and is designed for evaluation-budget comparisons,
  especially when local improvement and neighbourhood search are desired.
- For strict evaluation-budget experiments in the standard GA, disable FBF:

  ```python
  fb_improvement=False
  ```

- Stopping criteria in the standard GA can be combined; the first criterion reached
  is recorded as `stop_reason`.

